### PR TITLE
Fixture reschedule lifecycle, Rule 16 fix, and mid-season create guard

### DIFF
--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -54,11 +54,20 @@ func (h *DashboardHandler) HandleDashboard(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Fixtures awaiting reschedule (window passed, no result) — surfaced on the
+	// dashboard as a prominent nudge for captains to set a new date.
+	_, awaitingReschedule, err := h.service.GetHomeClubAwaitingRescheduleFixtures()
+	if err != nil {
+		log.Printf("Failed to load fixtures awaiting reschedule for dashboard: %v", err)
+		awaitingReschedule = nil // Non-fatal: dashboard still renders without the nudge
+	}
+
 	// Prepare template data
 	templateData := map[string]interface{}{
-		"User":          user,
-		"Stats":         dashboardData.Stats,
-		"LoginAttempts": dashboardData.LoginAttempts,
+		"User":               user,
+		"Stats":              dashboardData.Stats,
+		"LoginAttempts":      dashboardData.LoginAttempts,
+		"AwaitingReschedule": awaitingReschedule,
 	}
 
 	// Execute the template

--- a/internal/admin/fixtures.go
+++ b/internal/admin/fixtures.go
@@ -138,6 +138,14 @@ func (h *FixturesHandler) handleFixturesGet(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Fixtures awaiting reschedule (window passed, no result) — surfaced in their
+	// own prominent section to nudge captains to set a new date.
+	_, awaitingReschedule, err := h.service.GetHomeClubAwaitingRescheduleFixtures()
+	if err != nil {
+		logAndError(w, "Failed to load fixtures awaiting reschedule", err, http.StatusInternalServerError)
+		return
+	}
+
 	// Get the active season for filtering divisions, teams, and weeks
 	var divisions []models.Division
 	var weeks []models.Week
@@ -177,16 +185,17 @@ func (h *FixturesHandler) handleFixturesGet(w http.ResponseWriter, r *http.Reque
 
 	// Execute the template with data
 	if err := renderTemplate(w, tmpl, map[string]interface{}{
-		"User":             user,
-		"Club":             club,
-		"TodaysFixtures":   todaysFixtures,
-		"UpcomingFixtures": upcomingFixtures,
-		"PastFixtures":     pastFixtures,
-		"Divisions":        divisions,
-		"ActiveSeason":     activeSeason,
-		"Weeks":            weeks,
-		"Teams":            teams,
-		"HomeClubName":     homeClubNameFromContext(r),
+		"User":               user,
+		"Club":               club,
+		"TodaysFixtures":     todaysFixtures,
+		"UpcomingFixtures":   upcomingFixtures,
+		"PastFixtures":       pastFixtures,
+		"AwaitingReschedule": awaitingReschedule,
+		"Divisions":          divisions,
+		"ActiveSeason":       activeSeason,
+		"Weeks":              weeks,
+		"Teams":              teams,
+		"HomeClubName":       homeClubNameFromContext(r),
 	}); err != nil {
 		logAndError(w, err.Error(), err, http.StatusInternalServerError)
 	}
@@ -215,6 +224,15 @@ func (h *FixturesHandler) handleCreateFixture(w http.ResponseWriter, r *http.Req
 	}
 	if activeSeason == nil {
 		http.Error(w, "No active season found. Please create an active season first.", http.StatusBadRequest)
+		return
+	}
+
+	// Fixtures cannot be created once the season is under way. The fixture list is
+	// fixed at season setup; a change of date for an existing match is made by
+	// rescheduling that fixture, not by adding a new one. This guard stops the
+	// accidental duplicate fixtures captains create when they mean to reschedule.
+	if activeSeason.HasStarted() {
+		http.Error(w, "This season has already started, so new fixtures can't be created. To change a match date, open the existing fixture and use Edit Schedule to reschedule it.", http.StatusBadRequest)
 		return
 	}
 

--- a/internal/admin/matchcard_importation.go
+++ b/internal/admin/matchcard_importation.go
@@ -40,13 +40,14 @@ type MatchCardImportationPageData struct {
 
 // ImportRequest represents the form data for match card import
 type ImportRequest struct {
-	Week          int    `json:"week"`
-	Year          int    `json:"year"`
-	ClubName      string `json:"club_name"`
-	ClubID        int    `json:"club_id"`
-	ClubCode      string `json:"club_code"`
-	ClearExisting bool   `json:"clear_existing"`
-	DryRun        bool   `json:"dry_run"`
+	Week                  int    `json:"week"`
+	Year                  int    `json:"year"`
+	ClubName              string `json:"club_name"`
+	ClubID                int    `json:"club_id"`
+	ClubCode              string `json:"club_code"`
+	ClearExisting         bool   `json:"clear_existing"`
+	ClearUnplayedPairings bool   `json:"clear_unplayed_pairings"`
+	DryRun                bool   `json:"dry_run"`
 }
 
 // ImportResponse represents the results to display to the user
@@ -168,6 +169,7 @@ func (h *MatchCardImportationHandler) processImport(w http.ResponseWriter, r *ht
 		DryRun:                req.DryRun,
 		Verbose:               true, // Always verbose for web interface
 		ClearExistingMatchups: req.ClearExisting,
+		ClearUnplayedPairings: req.ClearUnplayedPairings,
 	}
 
 	// Run the import with auto-nonce extraction
@@ -212,13 +214,14 @@ func (h *MatchCardImportationHandler) parseImportRequest(r *http.Request) (*Impo
 	}
 
 	return &ImportRequest{
-		Week:          week,
-		Year:          year,
-		ClubName:      r.FormValue("club_name"),
-		ClubID:        clubID,
-		ClubCode:      r.FormValue("club_code"),
-		ClearExisting: r.FormValue("clear_existing") == "on",
-		DryRun:        r.FormValue("dry_run") == "on",
+		Week:                  week,
+		Year:                  year,
+		ClubName:              r.FormValue("club_name"),
+		ClubID:                clubID,
+		ClubCode:              r.FormValue("club_code"),
+		ClearExisting:         r.FormValue("clear_existing") == "on",
+		ClearUnplayedPairings: r.FormValue("clear_unplayed_pairings") == "on",
+		DryRun:                r.FormValue("dry_run") == "on",
 	}, nil
 }
 
@@ -365,6 +368,10 @@ func (h *MatchCardImportationHandler) generateStatsHTML(results *services.Import
 			</div>
 			<div class="stat-item">
 				<div class="stat-value">%d</div>
+				<div class="stat-label">Awaiting Reschedule</div>
+			</div>
+			<div class="stat-item">
+				<div class="stat-value">%d</div>
 				<div class="stat-label">Total Errors</div>
 			</div>
 		</div>
@@ -374,6 +381,7 @@ func (h *MatchCardImportationHandler) generateStatsHTML(results *services.Import
 		results.CreatedMatchups,
 		results.UpdatedMatchups,
 		results.MatchedPlayers,
+		results.AwaitingRescheduleFixtures,
 		len(results.Errors),
 	)
 }

--- a/internal/admin/service_dashboard.go
+++ b/internal/admin/service_dashboard.go
@@ -142,7 +142,7 @@ func (s *Service) getHomeClubFixtureCount(ctx context.Context) (int, error) {
 
 		// Filter for remaining fixtures (scheduled or in progress, today or later)
 		for _, fixture := range teamFixtures {
-			if fixture.Status == models.Scheduled || fixture.Status == models.InProgress {
+			if fixture.Status.IsPending() {
 				if fixture.ScheduledDate.After(now) || fixture.ScheduledDate.Equal(now.Truncate(24*time.Hour)) {
 					totalRemainingFixtures++
 				}

--- a/internal/admin/service_fixtures.go
+++ b/internal/admin/service_fixtures.go
@@ -921,6 +921,17 @@ func (s *Service) UpdateFixtureSchedule(fixtureID uint, newScheduledDate time.Ti
 		return fmt.Errorf("cannot reschedule completed fixture")
 	}
 
+	// A rescheduled fixture must stay within its season's year(s). A different year
+	// never makes sense and is almost always a date-picker fat-finger (e.g. year 0008
+	// instead of 2026), so reject it rather than corrupting the fixture.
+	if season, sErr := s.seasonRepository.FindByID(ctx, currentFixture.SeasonID); sErr == nil && season != nil &&
+		!season.StartDate.IsZero() && !season.EndDate.IsZero() {
+		if y := newScheduledDate.Year(); y < season.StartDate.Year() || y > season.EndDate.Year() {
+			return fmt.Errorf("the new date (%s) is outside the %d season — a fixture cannot be rescheduled to a different year",
+				newScheduledDate.Format("2 Jan 2006"), season.Year)
+		}
+	}
+
 	// Prepare the previous dates array
 	var previousDates []time.Time
 

--- a/internal/admin/service_fixtures.go
+++ b/internal/admin/service_fixtures.go
@@ -90,7 +90,7 @@ func (s *Service) GetHomeClubFixtures() (*models.Club, []FixtureWithRelations, e
 	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	tomorrowStart := todayStart.Add(24 * time.Hour)
 	for _, fixture := range allFixtures {
-		if fixture.Status == models.Scheduled || fixture.Status == models.InProgress {
+		if fixture.Status.IsPending() {
 			// Upcoming list excludes today's fixtures; those are shown separately
 			if !fixture.ScheduledDate.Before(tomorrowStart) {
 				upcomingFixtures = append(upcomingFixtures, fixture)
@@ -187,9 +187,11 @@ func (s *Service) GetHomeClubPastFixtures() (*models.Club, []FixtureWithRelation
 			continue
 		}
 
-		if fixture.Status == models.Completed || fixture.Status == models.Cancelled || fixture.Status == models.Postponed {
+		// AwaitingReschedule fixtures had their window pass with no result, so they
+		// belong in past fixtures where a captain can find them and set a new date.
+		if fixture.Status == models.Completed || fixture.Status == models.Cancelled || fixture.Status == models.Postponed || fixture.Status == models.AwaitingReschedule {
 			pastFixtures = append(pastFixtures, fixture)
-		} else if fixture.Status == models.Scheduled || fixture.Status == models.InProgress {
+		} else if fixture.Status.IsPending() {
 			if fixture.ScheduledDate.Before(todayStart) {
 				pastFixtures = append(pastFixtures, fixture)
 			}
@@ -221,6 +223,66 @@ func (s *Service) GetHomeClubPastFixtures() (*models.Club, []FixtureWithRelation
 
 		// For ascending order, return i < j
 		return divisionI < divisionJ
+	})
+
+	return homeClub, fixturesWithRelations, nil
+}
+
+// GetHomeClubAwaitingRescheduleFixtures returns the home club's active-season
+// fixtures currently in AwaitingReschedule status (window passed, no result), sorted
+// oldest first so the most overdue reschedules surface at the top. Used to
+// prominently nudge captains who have been slow to re-book cancelled fixtures.
+func (s *Service) GetHomeClubAwaitingRescheduleFixtures() (*models.Club, []FixtureWithRelations, error) {
+	ctx := context.Background()
+
+	activeSeason, err := s.seasonRepository.FindActive(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if activeSeason == nil {
+		return nil, nil, nil // No active season
+	}
+
+	homeClub, err := s.clubRepository.FindByID(ctx, s.homeClubID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	teams, err := s.teamRepository.FindByClub(ctx, homeClub.ID)
+	if err != nil {
+		return homeClub, nil, err
+	}
+	if len(teams) == 0 {
+		return homeClub, nil, nil
+	}
+
+	// Collect home-club fixtures, deduplicated (derbies appear under two teams).
+	fixtureMap := make(map[uint]models.Fixture)
+	for _, team := range teams {
+		teamFixtures, err := s.fixtureRepository.FindByTeam(ctx, team.ID)
+		if err != nil {
+			continue
+		}
+		for _, fixture := range teamFixtures {
+			fixtureMap[fixture.ID] = fixture
+		}
+	}
+
+	var awaiting []models.Fixture
+	for _, fixture := range fixtureMap {
+		if fixture.SeasonID != activeSeason.ID {
+			continue
+		}
+		if fixture.Status == models.AwaitingReschedule {
+			awaiting = append(awaiting, fixture)
+		}
+	}
+
+	fixturesWithRelations := s.buildFixturesWithRelations(ctx, awaiting, homeClub)
+
+	// Oldest scheduled date first — the longest-overdue reschedules lead.
+	sort.Slice(fixturesWithRelations, func(i, j int) bool {
+		return fixturesWithRelations[i].ScheduledDate.Before(fixturesWithRelations[j].ScheduledDate)
 	})
 
 	return homeClub, fixturesWithRelations, nil
@@ -272,7 +334,7 @@ func (s *Service) GetHomeClubTodaysFixtures() (*models.Club, []FixtureWithRelati
 	// Filter for today's fixtures
 	var todaysFixtures []models.Fixture
 	for _, fixture := range allFixtures {
-		if fixture.Status == models.Scheduled || fixture.Status == models.InProgress {
+		if fixture.Status.IsPending() {
 			if !fixture.ScheduledDate.Before(todayStart) && fixture.ScheduledDate.Before(tomorrowStart) {
 				todaysFixtures = append(todaysFixtures, fixture)
 			}
@@ -539,7 +601,7 @@ func (s *Service) GetUpcomingFixturesForTeam(teamID uint, limit int) ([]FixtureW
 	for _, fixture := range teamFixtures {
 		// Include fixtures that are today or in the future, and are scheduled or in progress
 		if (fixture.ScheduledDate.After(now) || fixture.ScheduledDate.After(today)) &&
-			(fixture.Status == models.Scheduled || fixture.Status == models.InProgress) {
+			(fixture.Status.IsPending()) {
 			upcomingFixtures = append(upcomingFixtures, fixture)
 		}
 	}
@@ -804,7 +866,7 @@ func (s *Service) GetHomeClubNextWeekFixturesByDivision() (map[string][]FixtureW
 		// Filter fixtures for next week and add to map to automatically deduplicate
 		for _, fixture := range teamFixtures {
 			if fixture.ScheduledDate.After(weekStart) && fixture.ScheduledDate.Before(weekEnd) {
-				if fixture.Status == models.Scheduled || fixture.Status == models.InProgress {
+				if fixture.Status.IsPending() {
 					fixtureMap[fixture.ID] = fixture
 				}
 			}
@@ -889,6 +951,10 @@ func (s *Service) UpdateFixtureSchedule(fixtureID uint, newScheduledDate time.Ti
 	updatedFixture.ScheduledDate = newScheduledDate
 	updatedFixture.PreviousDates = previousDates
 	updatedFixture.RescheduledReason = &rescheduleReason
+	// Moving a fixture to a new date marks it Rescheduled: still to-be-played
+	// (behaves like Scheduled for selection/availability) but distinguishable, and
+	// clears any AwaitingReschedule flag once a real future date is chosen.
+	updatedFixture.Status = models.Rescheduled
 	if notes != "" {
 		updatedFixture.Notes = notes
 	}
@@ -900,9 +966,37 @@ func (s *Service) UpdateFixtureSchedule(fixtureID uint, newScheduledDate time.Ti
 		return fmt.Errorf("failed to update fixture: %w", err)
 	}
 
+	// Always clear existing player selections AND matchups on reschedule. By the
+	// time a fixture rolls around (often months later) the same players won't all be
+	// available or destined for the same team, so captains expect a clean slate — a
+	// whole new fixture from the human perspective.
+	if err := s.ClearFixturePlayerSelection(fixtureID); err != nil {
+		// Non-fatal: the reschedule itself succeeded. Log and continue so a stale
+		// selection never blocks the date change.
+		log.Printf("Warning: failed to clear player selections after rescheduling fixture %d: %v", fixtureID, err)
+	}
+	if err := s.clearFixtureMatchups(ctx, fixtureID); err != nil {
+		log.Printf("Warning: failed to clear matchups after rescheduling fixture %d: %v", fixtureID, err)
+	}
+
 	log.Printf("Fixture %d rescheduled from %v to %v for reason: %s",
 		fixtureID, currentFixture.ScheduledDate, newScheduledDate, rescheduleReason)
 
+	return nil
+}
+
+// clearFixtureMatchups deletes all matchups for a fixture (matchup_players cascade
+// via the matchup delete). Used when rescheduling clears the pairings.
+func (s *Service) clearFixtureMatchups(ctx context.Context, fixtureID uint) error {
+	matchups, err := s.matchupRepository.FindByFixture(ctx, fixtureID)
+	if err != nil {
+		return err
+	}
+	for _, m := range matchups {
+		if err := s.matchupRepository.Delete(ctx, m.ID); err != nil {
+			return fmt.Errorf("failed to delete matchup %d: %w", m.ID, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/admin/service_fixtures.go
+++ b/internal/admin/service_fixtures.go
@@ -932,12 +932,11 @@ func (s *Service) UpdateFixtureSchedule(fixtureID uint, newScheduledDate time.Ti
 		}
 	}
 
-	// Prepare the previous dates array
-	var previousDates []time.Time
+	// Prepare the previous dates array (persisted as a JSON array in previous_dates)
+	var previousDates models.ScheduledDates
 
-	// Parse existing previous dates from JSON
+	// Carry forward any existing history
 	if len(currentFixture.PreviousDates) > 0 {
-		// Note: PreviousDates is already a []time.Time slice from the model
 		previousDates = currentFixture.PreviousDates
 	}
 

--- a/internal/admin/service_fixtures_test.go
+++ b/internal/admin/service_fixtures_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2025-2026 James Hartt. Licensed under the MIT License.
+
+package admin
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"jim-dot-tennis/internal/database"
+	"jim-dot-tennis/internal/models"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// A rescheduled fixture must stay within its season's year. A date-picker fat-finger
+// that lands the fixture in a different year (e.g. year 0008 instead of 2026, which
+// happened in production to fixture 529) must be rejected, not silently saved.
+func TestUpdateFixtureScheduleRejectsWrongYear(t *testing.T) {
+	tmp := t.TempDir()
+	db, err := database.New(database.Config{Driver: "sqlite3", FilePath: filepath.Join(tmp, "resched_year.db")})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	if err := db.ExecuteMigrations(findMigrationsPathAdmin(t)); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	ctx := context.Background()
+	exec := func(q string, args ...interface{}) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, q, args...); err != nil {
+			t.Fatalf("seed %q: %v", q, err)
+		}
+	}
+
+	seasonStart := time.Date(2026, 4, 14, 0, 0, 0, 0, time.UTC)
+	seasonEnd := time.Date(2026, 9, 30, 0, 0, 0, 0, time.UTC)
+	exec(`INSERT INTO seasons (id, name, year, start_date, end_date, is_active) VALUES (1, '2026 Season', 2026, ?, ?, 1)`, seasonStart, seasonEnd)
+	exec(`INSERT INTO weeks (id, week_number, season_id, start_date, end_date, name) VALUES (8, 8, 1, ?, ?, 'Week 8')`, seasonStart, seasonEnd)
+	exec(`INSERT INTO leagues (id, name, type, year, region) VALUES (1, 'Test League', 'Parks', 2026, 'Brighton')`)
+	exec(`INSERT INTO divisions (id, name, level, play_day, league_id, season_id) VALUES (1, 'Division 1', 1, 'Tuesday', 1, 1)`)
+	exec(`INSERT INTO clubs (id, name) VALUES (1, 'St Ann''s'), (2, 'Rivals')`)
+	exec(`INSERT INTO teams (id, name, club_id, division_id, season_id) VALUES (1, 'St Ann''s', 1, 1, 1), (2, 'Rivals', 2, 1, 1)`)
+	exec(`INSERT INTO fixtures (id, home_team_id, away_team_id, division_id, season_id, week_id, scheduled_date, venue_location, status, notes)
+		VALUES (900, 1, 2, 1, 1, 8, ?, '', 'Scheduled', '')`, time.Date(2026, 6, 2, 18, 0, 0, 0, time.UTC))
+
+	svc := NewService(db, "", 1, "")
+
+	// Wrong year (the year-8 fat-finger) must be rejected and the fixture left as-is.
+	badDate := time.Date(8, 9, 22, 14, 0, 0, 0, time.UTC)
+	if err := svc.UpdateFixtureSchedule(900, badDate, models.OtherReason, ""); err == nil {
+		t.Fatalf("expected an error rescheduling to year 8, got nil")
+	}
+	fx, err := svc.fixtureRepository.FindByID(ctx, 900)
+	if err != nil {
+		t.Fatalf("reload fixture: %v", err)
+	}
+	if fx.ScheduledDate.Year() != 2026 || fx.Status != models.Scheduled {
+		t.Fatalf("after rejected reschedule: got year=%d status=%s, want year=2026 status=Scheduled (fixture must be untouched)",
+			fx.ScheduledDate.Year(), fx.Status)
+	}
+
+	// A valid same-year date within the season is accepted and marks the fixture Rescheduled.
+	goodDate := time.Date(2026, 9, 22, 14, 0, 0, 0, time.UTC)
+	if err := svc.UpdateFixtureSchedule(900, goodDate, models.OtherReason, ""); err != nil {
+		t.Fatalf("valid same-year reschedule failed: %v", err)
+	}
+	fx, err = svc.fixtureRepository.FindByID(ctx, 900)
+	if err != nil {
+		t.Fatalf("reload fixture: %v", err)
+	}
+	if fx.Status != models.Rescheduled || !fx.ScheduledDate.Equal(goodDate) {
+		t.Fatalf("after valid reschedule: got status=%s date=%v, want status=Rescheduled date=%v",
+			fx.Status, fx.ScheduledDate, goodDate)
+	}
+}

--- a/internal/admin/service_fixtures_test.go
+++ b/internal/admin/service_fixtures_test.go
@@ -4,6 +4,7 @@ package admin
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -13,6 +14,45 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 )
+
+// TestTeamSelectionTemplatesParse guards the team-selection templates against
+// syntax errors (unbalanced {{if}}/{{end}}, unknown functions), which otherwise
+// only surface at render time. Covers the eligibility-wording edits.
+func TestTeamSelectionTemplatesParse(t *testing.T) {
+	dir := findTemplatesPathAdmin(t)
+	for _, name := range []string{
+		"admin/fixture_team_selection.html",
+		"admin/fixture_team_selection_container.html",
+	} {
+		if _, err := parseTemplate(dir, name); err != nil {
+			t.Errorf("parse %s: %v", name, err)
+		}
+	}
+}
+
+// findTemplatesPathAdmin walks up from the package directory to locate the
+// project's templates directory.
+func findTemplatesPathAdmin(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := cwd
+	for i := 0; i < 6; i++ {
+		candidate := filepath.Join(dir, "templates")
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatalf("could not locate templates directory from %s", cwd)
+	return ""
+}
 
 // A rescheduled fixture must stay within its season's year. A date-picker fat-finger
 // that lands the fixture in a different year (e.g. year 0008 instead of 2026, which

--- a/internal/admin/service_fixtures_test.go
+++ b/internal/admin/service_fixtures_test.go
@@ -76,4 +76,29 @@ func TestUpdateFixtureScheduleRejectsWrongYear(t *testing.T) {
 		t.Fatalf("after valid reschedule: got status=%s date=%v, want status=Rescheduled date=%v",
 			fx.Status, fx.ScheduledDate, goodDate)
 	}
+
+	// Audit trail must persist: the reason and the previous (original) date.
+	if fx.RescheduledReason == nil || *fx.RescheduledReason != models.OtherReason {
+		t.Fatalf("reschedule reason not persisted: got %v, want Other", fx.RescheduledReason)
+	}
+	origDate := time.Date(2026, 6, 2, 18, 0, 0, 0, time.UTC)
+	if len(fx.PreviousDates) != 1 || !fx.PreviousDates[0].Equal(origDate) {
+		t.Fatalf("previous_dates not persisted: got %v, want [%v]", fx.PreviousDates, origDate)
+	}
+
+	// A second reschedule must append (not replace) the history.
+	secondDate := time.Date(2026, 9, 29, 14, 0, 0, 0, time.UTC)
+	if err := svc.UpdateFixtureSchedule(900, secondDate, models.WeatherReason, ""); err != nil {
+		t.Fatalf("second reschedule failed: %v", err)
+	}
+	fx, err = svc.fixtureRepository.FindByID(ctx, 900)
+	if err != nil {
+		t.Fatalf("reload fixture: %v", err)
+	}
+	if len(fx.PreviousDates) != 2 || !fx.PreviousDates[1].Equal(goodDate) {
+		t.Fatalf("previous_dates should append the prior date: got %v, want [%v %v]", fx.PreviousDates, origDate, goodDate)
+	}
+	if fx.RescheduledReason == nil || *fx.RescheduledReason != models.WeatherReason {
+		t.Fatalf("reason should update to the latest: got %v, want Weather", fx.RescheduledReason)
+	}
 }

--- a/internal/admin/team_eligibility.go
+++ b/internal/admin/team_eligibility.go
@@ -157,9 +157,12 @@ func (s *TeamEligibilityService) GetPlayerEligibilityForTeam(ctx context.Context
 		isTopTeam := targetTeamRank == 1
 		eligibility.IsTopTeam = isTopTeam
 
-		// Count matches played in higher teams during the second half, up to and
-		// including this fixture's league week (excluding this fixture itself)
-		higherTeamMatches, lockedTeam, err := s.countHigherTeamMatchesInWeekRange(ctx, playerID, targetTeamRank, rankings, fixture.SeasonID, secondHalfStartWeek, playingWeek.WeekNumber, fixtureID)
+		// Count matches actually played in higher teams during the second half
+		// (from the second-half start onward), excluding this fixture itself. No
+		// upper week bound — see countHigherTeamMatchesFromWeek: a fixture
+		// rescheduled to the end of the season keeps its earlier league week, and
+		// bounding at that week would miss higher-team matches played in later weeks.
+		higherTeamMatches, lockedTeam, err := s.countHigherTeamMatchesFromWeek(ctx, playerID, targetTeamRank, rankings, fixture.SeasonID, secondHalfStartWeek, fixtureID)
 		if err != nil {
 			return nil, err
 		}
@@ -176,7 +179,7 @@ func (s *TeamEligibilityService) GetPlayerEligibilityForTeam(ctx context.Context
 		// For top team, no restrictions on higher team play since there are no higher teams
 		if isTopTeam {
 			// For top team, count matches in this team during the second half
-			currentTeamMatches, err := s.countCurrentTeamMatchesInWeekRange(ctx, playerID, teamID, fixture.SeasonID, secondHalfStartWeek, playingWeek.WeekNumber, fixtureID)
+			currentTeamMatches, err := s.countCurrentTeamMatchesFromWeek(ctx, playerID, teamID, fixture.SeasonID, secondHalfStartWeek, fixtureID)
 			if err != nil {
 				return nil, err
 			}
@@ -186,7 +189,7 @@ func (s *TeamEligibilityService) GetPlayerEligibilityForTeam(ctx context.Context
 			eligibility.CanPlayLower = true // Top team can always play lower teams
 		} else {
 			// For non-top teams, count matches in current team AND higher teams
-			currentTeamMatches, err := s.countCurrentTeamMatchesInWeekRange(ctx, playerID, teamID, fixture.SeasonID, secondHalfStartWeek, playingWeek.WeekNumber, fixtureID)
+			currentTeamMatches, err := s.countCurrentTeamMatchesFromWeek(ctx, playerID, teamID, fixture.SeasonID, secondHalfStartWeek, fixtureID)
 			if err != nil {
 				return nil, err
 			}
@@ -261,9 +264,18 @@ func (s *TeamEligibilityService) hasPlayerPlayedInCalendarWeek(ctx context.Conte
 	return true, teamName, nil
 }
 
-// countHigherTeamMatchesInWeekRange counts how many fixtures a player has played in higher-ranked
-// teams within a league week window (inclusive), excluding the fixture being selected for
-func (s *TeamEligibilityService) countHigherTeamMatchesInWeekRange(ctx context.Context, playerID string, targetTeamRank int, rankings []TeamRank, seasonID uint, startWeek int, endWeek int, excludeFixtureID uint) (int, string, error) {
+// countHigherTeamMatchesFromWeek counts how many fixtures a player has actually
+// played (Completed) in higher-ranked teams from the given league week onward,
+// excluding the fixture being selected for.
+//
+// There is deliberately NO upper week bound. Rule 16 is a running total of
+// higher-team matches played in the second half, and a fixture rescheduled to the
+// end of the season keeps its original (earlier) league week — so bounding the
+// count at the target fixture's week wrongly excluded higher-team matches the player
+// has since played in later weeks, under-counting and showing the wrong eligibility.
+// The Completed filter already excludes not-yet-played future matches, so normal
+// in-order fixtures are unaffected.
+func (s *TeamEligibilityService) countHigherTeamMatchesFromWeek(ctx context.Context, playerID string, targetTeamRank int, rankings []TeamRank, seasonID uint, startWeek int, excludeFixtureID uint) (int, string, error) {
 	// Get all teams ranked higher than the target team
 	var higherTeamIDs []uint
 	for _, ranking := range rankings {
@@ -291,7 +303,7 @@ func (s *TeamEligibilityService) countHigherTeamMatchesInWeekRange(ctx context.C
 		)
 		WHERE mp.player_id = ?
 		  AND f.season_id = ?
-		  AND w.week_number >= ? AND w.week_number <= ?
+		  AND w.week_number >= ?
 		  AND f.id != ?
 		  -- Rule 16 (played-down) counts matches actually PLAYED, so only Completed
 		  -- fixtures count. Fixtures that were scheduled but never played (rained
@@ -302,7 +314,7 @@ func (s *TeamEligibilityService) countHigherTeamMatchesInWeekRange(ctx context.C
 
 	// Build args slice
 	args := make([]interface{}, 0)
-	args = append(args, playerID, seasonID, startWeek, endWeek, excludeFixtureID)
+	args = append(args, playerID, seasonID, startWeek, excludeFixtureID)
 	// Team IDs for WHERE clause to filter higher teams
 	for _, teamID := range higherTeamIDs {
 		args = append(args, teamID)
@@ -325,9 +337,11 @@ func (s *TeamEligibilityService) countHigherTeamMatchesInWeekRange(ctx context.C
 	return count, lockedTeam, nil
 }
 
-// countCurrentTeamMatchesInWeekRange counts fixtures played for the specific team within a
-// league week window (inclusive), excluding the fixture being selected for
-func (s *TeamEligibilityService) countCurrentTeamMatchesInWeekRange(ctx context.Context, playerID string, teamID uint, seasonID uint, startWeek int, endWeek int, excludeFixtureID uint) (int, error) {
+// countCurrentTeamMatchesFromWeek counts fixtures a player has actually played
+// (Completed) for the specific team from the given league week onward, excluding the
+// fixture being selected for. Like countHigherTeamMatchesFromWeek, there is no upper
+// week bound so rescheduled fixtures played out of week-order are counted correctly.
+func (s *TeamEligibilityService) countCurrentTeamMatchesFromWeek(ctx context.Context, playerID string, teamID uint, seasonID uint, startWeek int, excludeFixtureID uint) (int, error) {
 	query := `
 		SELECT COUNT(DISTINCT f.id)
 		FROM matchup_players mp
@@ -336,7 +350,7 @@ func (s *TeamEligibilityService) countCurrentTeamMatchesInWeekRange(ctx context.
 		INNER JOIN weeks w ON f.week_id = w.id
 		WHERE mp.player_id = ?
 		  AND f.season_id = ?
-		  AND w.week_number >= ? AND w.week_number <= ?
+		  AND w.week_number >= ?
 		  AND f.id != ?
 		  -- Rule 16 (played-down) counts matches actually PLAYED, so only Completed
 		  -- fixtures count toward a player's tally for this team.
@@ -348,7 +362,7 @@ func (s *TeamEligibilityService) countCurrentTeamMatchesInWeekRange(ctx context.
 	`
 
 	var count int
-	err := s.service.db.GetContext(ctx, &count, query, playerID, seasonID, startWeek, endWeek, excludeFixtureID, teamID, teamID)
+	err := s.service.db.GetContext(ctx, &count, query, playerID, seasonID, startWeek, excludeFixtureID, teamID, teamID)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/admin/team_eligibility.go
+++ b/internal/admin/team_eligibility.go
@@ -240,7 +240,11 @@ func (s *TeamEligibilityService) hasPlayerPlayedInCalendarWeek(ctx context.Conte
 		LEFT JOIN fixture_players fp ON fp.fixture_id = f.id AND fp.player_id = ?
 		WHERE f.scheduled_date >= ? AND f.scheduled_date < ?
 		  AND f.id != ?
-		  AND f.status IN ('Scheduled', 'InProgress', 'Completed')
+		  -- Rule 1 forbids playing OR being scheduled to play for two teams in the
+		  -- same calendar week, so pending fixtures count. Rescheduled is still
+		  -- to-be-played and is included; AwaitingReschedule (no valid date),
+		  -- Cancelled and Postponed are not.
+		  AND f.status IN ('Scheduled', 'InProgress', 'Completed', 'Rescheduled')
 		  AND (mp.player_id IS NOT NULL OR fp.player_id IS NOT NULL)
 		  AND (
 		    (COALESCE(mp.is_home, fp.is_home) = 1 AND th.club_id = ?) OR
@@ -289,7 +293,10 @@ func (s *TeamEligibilityService) countHigherTeamMatchesInWeekRange(ctx context.C
 		  AND f.season_id = ?
 		  AND w.week_number >= ? AND w.week_number <= ?
 		  AND f.id != ?
-		  AND f.status IN ('Scheduled', 'InProgress', 'Completed')
+		  -- Rule 16 (played-down) counts matches actually PLAYED, so only Completed
+		  -- fixtures count. Fixtures that were scheduled but never played (rained
+		  -- off, or not yet imported) must not lock a player out of a lower team.
+		  AND f.status = 'Completed'
 		  AND t.id IN (` + s.createPlaceholders(len(higherTeamIDs)) + `)
 	`
 
@@ -331,7 +338,9 @@ func (s *TeamEligibilityService) countCurrentTeamMatchesInWeekRange(ctx context.
 		  AND f.season_id = ?
 		  AND w.week_number >= ? AND w.week_number <= ?
 		  AND f.id != ?
-		  AND f.status IN ('Scheduled', 'InProgress', 'Completed')
+		  -- Rule 16 (played-down) counts matches actually PLAYED, so only Completed
+		  -- fixtures count toward a player's tally for this team.
+		  AND f.status = 'Completed'
 		  AND (
 			(f.home_team_id = ? AND mp.is_home = 1) OR
 			(f.away_team_id = ? AND mp.is_home = 0)

--- a/internal/admin/team_eligibility.go
+++ b/internal/admin/team_eligibility.go
@@ -141,7 +141,19 @@ func (s *TeamEligibilityService) GetPlayerEligibilityForTeam(ctx context.Context
 		return nil, err
 	}
 
-	if playingWeek.WeekNumber >= secondHalfStartWeek {
+	// Rule 16 applies to matches played in the second half of the season. Normally
+	// the league week number decides this. But a fixture rescheduled out of its
+	// original week keeps its (earlier) week_id while being physically played on its
+	// scheduled_date, so a first-half-week fixture rescheduled to a second-half date
+	// (e.g. a week-8 fixture moved to September) is a second-half match and Rule 16
+	// must apply. Treat the fixture as second-half if EITHER its league week is in
+	// the second half OR its scheduled date falls in the second half of the season.
+	inSecondHalf := playingWeek.WeekNumber >= secondHalfStartWeek
+	if !inSecondHalf && s.scheduledInSecondHalf(ctx, fixture) {
+		inSecondHalf = true
+	}
+
+	if inSecondHalf {
 		// Get team rankings to determine which teams are "higher"
 		rankings, err := s.GetTeamRanking(ctx, targetTeam.ClubID, fixture.SeasonID)
 		if err != nil {
@@ -396,6 +408,21 @@ func (s *TeamEligibilityService) getSecondHalfStartWeek(ctx context.Context, sea
 		return 10, nil
 	}
 	return len(weeks)/2 + 1, nil
+}
+
+// scheduledInSecondHalf reports whether the fixture's scheduled date falls in the
+// second half of its season — on or after the midpoint between the season's start
+// and end dates. Used so Rule 16 applies to fixtures rescheduled out of a first-half
+// league week into the second half (their week_id stays first-half, but they are
+// played in the second half). Uses the real season start/end dates, NOT the weeks
+// table, whose windows drift from the real fixture calendar.
+func (s *TeamEligibilityService) scheduledInSecondHalf(ctx context.Context, fixture *models.Fixture) bool {
+	season, err := s.service.seasonRepository.FindByID(ctx, fixture.SeasonID)
+	if err != nil || season == nil || season.StartDate.IsZero() || season.EndDate.IsZero() {
+		return false
+	}
+	midpoint := season.StartDate.Add(season.EndDate.Sub(season.StartDate) / 2)
+	return !fixture.ScheduledDate.Before(midpoint)
 }
 
 // mondayToSaturdayWindow returns Monday 00:00 (inclusive) to Saturday 00:00 (exclusive) for the week of the given date

--- a/internal/admin/team_eligibility_test.go
+++ b/internal/admin/team_eligibility_test.go
@@ -413,6 +413,113 @@ func TestPlayDownRescheduledFixtureCountsLaterWeeks(t *testing.T) {
 	}
 }
 
+// Regression test: a fixture whose league week is in the FIRST half but which has
+// been rescheduled to a second-half date must have Rule 16 applied — "second half
+// plus rescheduled". A first-half fixture played on time must NOT.
+func TestPlayDownFirstHalfWeekRescheduledToSecondHalf(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "eligibility_firsthalf_resched_test.db")
+
+	db, err := database.New(database.Config{Driver: "sqlite3", FilePath: dbPath})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.ExecuteMigrations(findMigrationsPathAdmin(t)); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	ctx := context.Background()
+	exec := func(query string, args ...interface{}) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, query, args...); err != nil {
+			t.Fatalf("seed %q: %v", query, err)
+		}
+	}
+
+	seasonStart := time.Date(2026, 4, 14, 0, 0, 0, 0, time.UTC)
+	seasonEnd := time.Date(2026, 9, 30, 0, 0, 0, 0, time.UTC)
+	exec(`INSERT INTO seasons (id, name, year, start_date, end_date, is_active) VALUES (1, '2026 Season', 2026, ?, ?, 1)`, seasonStart, seasonEnd)
+
+	const numWeeks = 18
+	totalDays := seasonEnd.Sub(seasonStart).Hours() / 24
+	daysPerWeek := totalDays / float64(numWeeks)
+	for i := 1; i <= numWeeks; i++ {
+		weekStart := seasonStart.AddDate(0, 0, int(float64(i-1)*daysPerWeek))
+		weekEnd := seasonStart.AddDate(0, 0, int(float64(i)*daysPerWeek)-1)
+		if i == numWeeks {
+			weekEnd = seasonEnd
+		}
+		exec(`INSERT INTO weeks (id, week_number, season_id, start_date, end_date, name) VALUES (?, ?, 1, ?, ?, ?)`,
+			i, i, weekStart, weekEnd, fmt.Sprintf("Week %d", i))
+	}
+
+	exec(`INSERT INTO leagues (id, name, type, year, region) VALUES (1, 'Test League', 'Parks', 2026, 'Brighton')`)
+	exec(`INSERT INTO divisions (id, name, level, play_day, league_id, season_id) VALUES (1, 'Division 1', 1, 'Tuesday', 1, 1)`)
+	exec(`INSERT INTO clubs (id, name) VALUES (1, 'St Ann''s'), (2, 'Rivals')`)
+	exec(`INSERT INTO teams (id, name, club_id, division_id, season_id) VALUES
+		(1, 'St Ann''s',   1, 1, 1),
+		(2, 'St Ann''s B', 1, 1, 1),
+		(3, 'St Ann''s C', 1, 1, 1),
+		(4, 'Rivals',      2, 1, 1),
+		(5, 'Rivals B',    2, 1, 1)`)
+	exec(`INSERT INTO players (id, first_name, last_name, club_id) VALUES ('p1', 'Test', 'Player', 1)`)
+
+	fixtureDate := func(weekNumber int) time.Time {
+		return seasonStart.AddDate(0, 0, (weekNumber-1)*7)
+	}
+
+	// Five higher-team (rank 1) matches actually played in the second half (weeks
+	// 10-14) — enough to lock the player out of a lower team under Rule 16.
+	playedUp := func(weekNumber int) {
+		t.Helper()
+		fixtureID := 100 + weekNumber
+		exec(`INSERT INTO fixtures (id, home_team_id, away_team_id, division_id, season_id, week_id, scheduled_date, venue_location, status, notes)
+			VALUES (?, 1, 4, 1, 1, ?, ?, '', 'Completed', '')`, fixtureID, weekNumber, fixtureDate(weekNumber))
+		exec(`INSERT INTO matchups (id, fixture_id, type, status) VALUES (?, ?, 'Mens', 'Finished')`, fixtureID, fixtureID)
+		exec(`INSERT INTO matchup_players (matchup_id, player_id, is_home) VALUES (?, 'p1', 1)`, fixtureID)
+	}
+	for w := 10; w <= 14; w++ {
+		playedUp(w)
+	}
+
+	// Target A: St Ann's B, league week 8 (first half), played ON TIME in week 8.
+	const onTimeFixtureID = 700
+	exec(`INSERT INTO fixtures (id, home_team_id, away_team_id, division_id, season_id, week_id, scheduled_date, venue_location, status, notes)
+		VALUES (?, 2, 5, 1, 1, 8, ?, '', 'Scheduled', '')`, onTimeFixtureID, fixtureDate(8))
+
+	// Target B: same league week 8, but RESCHEDULED to the end of the season.
+	const rescheduledFixtureID = 701
+	lateDate := seasonEnd.AddDate(0, 0, -10) // clearly in the second half by date
+	exec(`INSERT INTO fixtures (id, home_team_id, away_team_id, division_id, season_id, week_id, scheduled_date, venue_location, status, notes)
+		VALUES (?, 2, 5, 1, 1, 8, ?, '', 'Rescheduled', '')`, rescheduledFixtureID, lateDate)
+
+	svc := NewService(db, "", 1, "")
+	elig := svc.teamEligibilityService
+
+	// On-time first-half fixture: Rule 16 does not apply despite 5 higher-team plays.
+	onTime, err := elig.GetPlayerEligibilityForTeam(ctx, "p1", 2, onTimeFixtureID)
+	if err != nil {
+		t.Fatalf("on-time fixture: %v", err)
+	}
+	if !onTime.CanPlay || onTime.IsLockedToHigherTeam || onTime.RemainingHigherTeamPlays != -1 {
+		t.Fatalf("on-time first-half fixture: got CanPlay=%v Locked=%v Remaining=%d, want CanPlay=true Locked=false Remaining=-1 (Rule 16 must not apply)",
+			onTime.CanPlay, onTime.IsLockedToHigherTeam, onTime.RemainingHigherTeamPlays)
+	}
+
+	// Same league week, rescheduled into the second half: Rule 16 applies and the
+	// 5 higher-team plays lock the player out.
+	resched, err := elig.GetPlayerEligibilityForTeam(ctx, "p1", 2, rescheduledFixtureID)
+	if err != nil {
+		t.Fatalf("rescheduled fixture: %v", err)
+	}
+	if resched.CanPlay || !resched.IsLockedToHigherTeam {
+		t.Fatalf("first-half fixture rescheduled to second half: got CanPlay=%v Locked=%v, want CanPlay=false Locked=true (Rule 16 must apply)",
+			resched.CanPlay, resched.IsLockedToHigherTeam)
+	}
+}
+
 // findMigrationsPathAdmin walks up from the package directory to locate the
 // project's migrations directory.
 func findMigrationsPathAdmin(t *testing.T) string {

--- a/internal/admin/team_eligibility_test.go
+++ b/internal/admin/team_eligibility_test.go
@@ -167,6 +167,121 @@ func TestPlayDownEligibilitySecondHalf(t *testing.T) {
 	}
 }
 
+// Regression test for the July 2026 "Liv" bug: fixtures that were scheduled for a
+// higher team but never played (rained/heated off, or simply not yet imported)
+// were counting toward Rule 16 and wrongly locking players out of a lower team.
+// Only Completed matches — matches actually played — must count.
+func TestPlayDownIgnoresUnplayedHigherTeamFixtures(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "eligibility_unplayed_test.db")
+
+	db, err := database.New(database.Config{Driver: "sqlite3", FilePath: dbPath})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.ExecuteMigrations(findMigrationsPathAdmin(t)); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	ctx := context.Background()
+	exec := func(query string, args ...interface{}) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, query, args...); err != nil {
+			t.Fatalf("seed %q: %v", query, err)
+		}
+	}
+
+	seasonStart := time.Date(2026, 4, 14, 0, 0, 0, 0, time.UTC)
+	seasonEnd := time.Date(2026, 9, 30, 0, 0, 0, 0, time.UTC)
+	exec(`INSERT INTO seasons (id, name, year, start_date, end_date, is_active) VALUES (1, '2026 Season', 2026, ?, ?, 1)`, seasonStart, seasonEnd)
+
+	const numWeeks = 18
+	totalDays := seasonEnd.Sub(seasonStart).Hours() / 24
+	daysPerWeek := totalDays / float64(numWeeks)
+	for i := 1; i <= numWeeks; i++ {
+		weekStart := seasonStart.AddDate(0, 0, int(float64(i-1)*daysPerWeek))
+		weekEnd := seasonStart.AddDate(0, 0, int(float64(i)*daysPerWeek)-1)
+		if i == numWeeks {
+			weekEnd = seasonEnd
+		}
+		exec(`INSERT INTO weeks (id, week_number, season_id, start_date, end_date, name) VALUES (?, ?, 1, ?, ?, ?)`,
+			i, i, weekStart, weekEnd, fmt.Sprintf("Week %d", i))
+	}
+
+	exec(`INSERT INTO leagues (id, name, type, year, region) VALUES (1, 'Test League', 'Parks', 2026, 'Brighton')`)
+	exec(`INSERT INTO divisions (id, name, level, play_day, league_id, season_id) VALUES (1, 'Division 1', 1, 'Tuesday', 1, 1)`)
+	exec(`INSERT INTO clubs (id, name) VALUES (1, 'St Ann''s'), (2, 'Rivals')`)
+	exec(`INSERT INTO teams (id, name, club_id, division_id, season_id) VALUES
+		(1, 'St Ann''s',   1, 1, 1),
+		(2, 'St Ann''s B', 1, 1, 1),
+		(3, 'St Ann''s C', 1, 1, 1),
+		(4, 'Rivals',      2, 1, 1),
+		(5, 'Rivals B',    2, 1, 1)`)
+	exec(`INSERT INTO players (id, first_name, last_name, club_id) VALUES ('p1', 'Liv', 'Player', 1)`)
+
+	fixtureDate := func(weekNumber int) time.Time {
+		return seasonStart.AddDate(0, 0, (weekNumber-1)*7)
+	}
+
+	// A higher-team (rank 1) fixture in the given league week with the player
+	// selected, at an arbitrary status. status 'Completed' = actually played.
+	playedUpWithStatus := func(weekNumber int, status string) {
+		t.Helper()
+		fixtureID := 100 + weekNumber
+		matchupID := 100 + weekNumber
+		exec(`INSERT INTO fixtures (id, home_team_id, away_team_id, division_id, season_id, week_id, scheduled_date, venue_location, status, notes)
+			VALUES (?, 1, 4, 1, 1, ?, ?, '', ?, '')`, fixtureID, weekNumber, fixtureDate(weekNumber), status)
+		exec(`INSERT INTO matchups (id, fixture_id, type, status) VALUES (?, ?, 'Mens', 'Finished')`, matchupID, fixtureID)
+		exec(`INSERT INTO matchup_players (matchup_id, player_id, is_home) VALUES (?, 'p1', 1)`, matchupID)
+	}
+
+	// Target: lower team (St Ann's B) in league week 15.
+	const targetFixtureID = 500
+	exec(`INSERT INTO fixtures (id, home_team_id, away_team_id, division_id, season_id, week_id, scheduled_date, venue_location, status, notes)
+		VALUES (?, 2, 5, 1, 1, 15, ?, '', 'Scheduled', '')`, targetFixtureID, fixtureDate(15))
+
+	svc := NewService(db, "", 1, "")
+	elig := svc.teamEligibilityService
+
+	remaining := func(name string) *PlayerEligibilityInfo {
+		t.Helper()
+		got, err := elig.GetPlayerEligibilityForTeam(ctx, "p1", 2, targetFixtureID)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		return got
+	}
+
+	// Two matches actually played up (weeks 10, 11) → 2 count, 2 remaining.
+	playedUpWithStatus(10, "Completed")
+	playedUpWithStatus(11, "Completed")
+	if got := remaining("2 completed"); got.RemainingHigherTeamPlays != 2 || !got.CanPlay {
+		t.Fatalf("2 completed: got Remaining=%d CanPlay=%v, want Remaining=2 CanPlay=true", got.RemainingHigherTeamPlays, got.CanPlay)
+	}
+
+	// Three MORE higher-team fixtures that never got played: Scheduled,
+	// Rescheduled, and AwaitingReschedule. Under the old bug these would push the
+	// tally to 5 and lock the player out. They must be ignored entirely.
+	playedUpWithStatus(12, "Scheduled")
+	playedUpWithStatus(13, "Rescheduled")
+	playedUpWithStatus(14, "AwaitingReschedule")
+	if got := remaining("unplayed ignored"); got.RemainingHigherTeamPlays != 2 || !got.CanPlay || got.IsLockedToHigherTeam {
+		t.Fatalf("unplayed ignored: got Remaining=%d CanPlay=%v Locked=%v, want Remaining=2 CanPlay=true Locked=false",
+			got.RemainingHigherTeamPlays, got.CanPlay, got.IsLockedToHigherTeam)
+	}
+
+	// Flip the three unplayed higher-team fixtures (weeks 12-14, ids 112-114) to
+	// Completed: now 5 matches actually played up in the counted window (weeks
+	// 10-14), which locks the player. Confirms the rule itself is intact — only
+	// unplayed fixtures were being wrongly counted before the fix.
+	exec(`UPDATE fixtures SET status = 'Completed' WHERE id IN (112, 113, 114)`)
+	if got := remaining("5 completed locks"); got.CanPlay || !got.IsLockedToHigherTeam {
+		t.Fatalf("5 completed locks: got CanPlay=%v Locked=%v, want CanPlay=false Locked=true", got.CanPlay, got.IsLockedToHigherTeam)
+	}
+}
+
 // findMigrationsPathAdmin walks up from the package directory to locate the
 // project's migrations directory.
 func findMigrationsPathAdmin(t *testing.T) string {

--- a/internal/admin/team_eligibility_test.go
+++ b/internal/admin/team_eligibility_test.go
@@ -282,6 +282,137 @@ func TestPlayDownIgnoresUnplayedHigherTeamFixtures(t *testing.T) {
 	}
 }
 
+// Regression test for the end-of-season rescheduled-fixture bug: a fixture
+// rescheduled to the end of the season keeps its original (earlier) league week, so
+// bounding the played-down count at the target fixture's week wrongly excluded
+// higher-team matches the player has since played in LATER weeks. Rule 16 must count
+// all Completed higher-team matches from the second-half start onward, regardless of
+// the target fixture's week. Un-played (non-Completed) later matches must still be
+// ignored.
+func TestPlayDownRescheduledFixtureCountsLaterWeeks(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "eligibility_rescheduled_test.db")
+
+	db, err := database.New(database.Config{Driver: "sqlite3", FilePath: dbPath})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.ExecuteMigrations(findMigrationsPathAdmin(t)); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	ctx := context.Background()
+	exec := func(query string, args ...interface{}) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, query, args...); err != nil {
+			t.Fatalf("seed %q: %v", query, err)
+		}
+	}
+
+	seasonStart := time.Date(2026, 4, 14, 0, 0, 0, 0, time.UTC)
+	seasonEnd := time.Date(2026, 9, 30, 0, 0, 0, 0, time.UTC)
+	exec(`INSERT INTO seasons (id, name, year, start_date, end_date, is_active) VALUES (1, '2026 Season', 2026, ?, ?, 1)`, seasonStart, seasonEnd)
+
+	const numWeeks = 18
+	totalDays := seasonEnd.Sub(seasonStart).Hours() / 24
+	daysPerWeek := totalDays / float64(numWeeks)
+	for i := 1; i <= numWeeks; i++ {
+		weekStart := seasonStart.AddDate(0, 0, int(float64(i-1)*daysPerWeek))
+		weekEnd := seasonStart.AddDate(0, 0, int(float64(i)*daysPerWeek)-1)
+		if i == numWeeks {
+			weekEnd = seasonEnd
+		}
+		exec(`INSERT INTO weeks (id, week_number, season_id, start_date, end_date, name) VALUES (?, ?, 1, ?, ?, ?)`,
+			i, i, weekStart, weekEnd, fmt.Sprintf("Week %d", i))
+	}
+
+	exec(`INSERT INTO leagues (id, name, type, year, region) VALUES (1, 'Test League', 'Parks', 2026, 'Brighton')`)
+	exec(`INSERT INTO divisions (id, name, level, play_day, league_id, season_id) VALUES (1, 'Division 1', 1, 'Tuesday', 1, 1)`)
+	exec(`INSERT INTO clubs (id, name) VALUES (1, 'St Ann''s'), (2, 'Rivals')`)
+	exec(`INSERT INTO teams (id, name, club_id, division_id, season_id) VALUES
+		(1, 'St Ann''s',   1, 1, 1),
+		(2, 'St Ann''s B', 1, 1, 1),
+		(3, 'St Ann''s C', 1, 1, 1),
+		(4, 'Rivals',      2, 1, 1),
+		(5, 'Rivals B',    2, 1, 1)`)
+	exec(`INSERT INTO players (id, first_name, last_name, club_id) VALUES ('p1', 'Test', 'Player', 1)`)
+
+	fixtureDate := func(weekNumber int) time.Time {
+		return seasonStart.AddDate(0, 0, (weekNumber-1)*7)
+	}
+
+	// A higher-team (rank 1) fixture in the given league week with the player
+	// selected, at an arbitrary status. status 'Completed' = actually played.
+	higherTeamMatch := func(weekNumber int, status string) {
+		t.Helper()
+		fixtureID := 100 + weekNumber
+		matchupID := 100 + weekNumber
+		exec(`INSERT INTO fixtures (id, home_team_id, away_team_id, division_id, season_id, week_id, scheduled_date, venue_location, status, notes)
+			VALUES (?, 1, 4, 1, 1, ?, ?, '', ?, '')`, fixtureID, weekNumber, fixtureDate(weekNumber), status)
+		exec(`INSERT INTO matchups (id, fixture_id, type, status) VALUES (?, ?, 'Mens', 'Finished')`, matchupID, fixtureID)
+		exec(`INSERT INTO matchup_players (matchup_id, player_id, is_home) VALUES (?, 'p1', 1)`, matchupID)
+	}
+
+	// Target: lower team (St Ann's B, rank 2) fixture whose league week is 11 (second
+	// half) but which has been RESCHEDULED to the very end of the season. Its week_id
+	// stays 11; it is physically the last match played.
+	const targetFixtureID = 600
+	lateDate := seasonEnd.AddDate(0, 0, -3) // end of season, after weeks 12-17
+	exec(`INSERT INTO fixtures (id, home_team_id, away_team_id, division_id, season_id, week_id, scheduled_date, venue_location, status, notes)
+		VALUES (?, 2, 5, 1, 1, 11, ?, '', 'Rescheduled', '')`, targetFixtureID, lateDate)
+
+	svc := NewService(db, "", 1, "")
+	elig := svc.teamEligibilityService
+
+	get := func(name string) *PlayerEligibilityInfo {
+		t.Helper()
+		got, err := elig.GetPlayerEligibilityForTeam(ctx, "p1", 2, targetFixtureID)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		return got
+	}
+
+	// Three higher-team matches played in weeks 12-14 — ALL in weeks AFTER the target
+	// fixture's league week (11). The pre-fix code bounded the count at week 11 and
+	// missed every one of them; they must now count.
+	higherTeamMatch(12, "Completed")
+	higherTeamMatch(13, "Completed")
+	higherTeamMatch(14, "Completed")
+	if got := get("3 later-week higher matches"); !got.CanPlay || got.RemainingHigherTeamPlays != 1 {
+		t.Fatalf("3 later-week higher matches: got CanPlay=%v Remaining=%d, want CanPlay=true Remaining=1 (later-week matches must count for a rescheduled fixture)",
+			got.CanPlay, got.RemainingHigherTeamPlays)
+	}
+
+	// An un-played (Scheduled) higher-team match in a later week must NOT count —
+	// only Completed matches do, so removing the upper week bound doesn't over-count
+	// future fixtures.
+	higherTeamMatch(17, "Scheduled")
+	if got := get("scheduled later-week match ignored"); !got.CanPlay || got.RemainingHigherTeamPlays != 1 {
+		t.Fatalf("scheduled later-week match ignored: got CanPlay=%v Remaining=%d, want CanPlay=true Remaining=1",
+			got.CanPlay, got.RemainingHigherTeamPlays)
+	}
+
+	// A fourth completed higher-team match (week 15): at the Rule 16 limit but still
+	// eligible.
+	higherTeamMatch(15, "Completed")
+	if got := get("4 later-week higher matches"); !got.CanPlay || got.RemainingHigherTeamPlays != 0 {
+		t.Fatalf("4 later-week higher matches: got CanPlay=%v Remaining=%d, want CanPlay=true Remaining=0",
+			got.CanPlay, got.RemainingHigherTeamPlays)
+	}
+
+	// A fifth completed higher-team match (week 16): more than four, locked to the
+	// higher team — even though every higher-team match is in a week AFTER the target
+	// fixture's league week.
+	higherTeamMatch(16, "Completed")
+	if got := get("5 later-week higher matches locks"); got.CanPlay || !got.IsLockedToHigherTeam {
+		t.Fatalf("5 later-week higher matches: got CanPlay=%v Locked=%v, want CanPlay=false Locked=true",
+			got.CanPlay, got.IsLockedToHigherTeam)
+	}
+}
+
 // findMigrationsPathAdmin walks up from the package directory to locate the
 // project's migrations directory.
 func findMigrationsPathAdmin(t *testing.T) string {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -3,6 +3,9 @@
 package models
 
 import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -262,6 +265,52 @@ const (
 	OtherReason       RescheduledReason = "Other"             // Other reasons
 )
 
+// ScheduledDates is a list of fixture dates persisted to a single TEXT column as a
+// JSON array (the fixtures.previous_dates column). It implements driver.Valuer and
+// sql.Scanner so the repository can read and write it directly.
+type ScheduledDates []time.Time
+
+// Value serialises the date list to a JSON array string ("[]" when empty) for
+// storage in the previous_dates TEXT column.
+func (d ScheduledDates) Value() (driver.Value, error) {
+	if len(d) == 0 {
+		return "[]", nil
+	}
+	b, err := json.Marshal([]time.Time(d))
+	if err != nil {
+		return nil, err
+	}
+	return string(b), nil
+}
+
+// Scan reads the JSON array (string or []byte) from the previous_dates column. NULL
+// or empty input yields a nil slice.
+func (d *ScheduledDates) Scan(src interface{}) error {
+	if src == nil {
+		*d = nil
+		return nil
+	}
+	var b []byte
+	switch v := src.(type) {
+	case []byte:
+		b = v
+	case string:
+		b = []byte(v)
+	default:
+		return fmt.Errorf("ScheduledDates.Scan: unsupported source type %T", src)
+	}
+	if len(b) == 0 {
+		*d = nil
+		return nil
+	}
+	var out []time.Time
+	if err := json.Unmarshal(b, &out); err != nil {
+		return fmt.Errorf("ScheduledDates.Scan: %w", err)
+	}
+	*d = out
+	return nil
+}
+
 // Fixture represents a scheduled match between two teams
 type Fixture struct {
 	ID                  uint               `json:"id" db:"id"`
@@ -277,7 +326,7 @@ type Fixture struct {
 	DayCaptainID        *string            `json:"day_captain_id,omitempty" db:"day_captain_id"`                 // Optional day captain for this fixture (UUID)
 	ExternalMatchCardID *int               `json:"external_match_card_id,omitempty" db:"external_match_card_id"` // BHPLTA match card ID
 	Notes               string             `json:"notes" db:"notes"`
-	PreviousDates       []time.Time        `json:"previous_dates,omitempty" db:"previous_dates"`         // Previous scheduled dates (stored as JSON)
+	PreviousDates       ScheduledDates     `json:"previous_dates,omitempty" db:"previous_dates"`         // Previous scheduled dates (stored as a JSON array)
 	RescheduledReason   *RescheduledReason `json:"rescheduled_reason,omitempty" db:"rescheduled_reason"` // Reason for rescheduling
 	VenueClubID         *uint              `json:"venue_club_id,omitempty" db:"venue_club_id"`           // Per-fixture venue override (FK to clubs)
 	CreatedAt           time.Time          `json:"created_at" db:"created_at"`

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -20,6 +20,13 @@ type Season struct {
 	Weeks     []Week    `json:"weeks,omitempty"`   // Weeks in this season
 }
 
+// HasStarted reports whether the season's start date has passed. Once a season is
+// under way its fixture list is fixed — mid-season changes are made by rescheduling
+// an existing fixture, not by creating new ones.
+func (s Season) HasStarted() bool {
+	return !s.StartDate.IsZero() && !time.Now().Before(s.StartDate)
+}
+
 // Week represents a specific week within a season
 type Week struct {
 	ID         uint      `json:"id" db:"id"`
@@ -215,7 +222,36 @@ const (
 	Completed  FixtureStatus = "Completed"  // Fixture is completed
 	Cancelled  FixtureStatus = "Cancelled"  // Fixture was cancelled
 	Postponed  FixtureStatus = "Postponed"  // Fixture was postponed
+	// Rescheduled is a still-to-be-played fixture that a captain moved to a new
+	// future date. It behaves like Scheduled for selection and availability but is
+	// tracked separately so captains can see a fixture has been moved, and so the
+	// played-down rule (Rule 16) can ignore it (only Completed matches count).
+	Rescheduled FixtureStatus = "Rescheduled"
+	// AwaitingReschedule is a fixture whose play window passed with no match card
+	// imported. The post-import sweep flips leftover fixtures into this status so
+	// captains know a new date is needed. It is not selectable or "upcoming".
+	AwaitingReschedule FixtureStatus = "AwaitingReschedule"
 )
+
+// IsPending reports whether the fixture is still to be played and can have players
+// selected for it: Scheduled, InProgress, or Rescheduled. AwaitingReschedule is not
+// pending — it has no valid future date until a captain reschedules it.
+func (s FixtureStatus) IsPending() bool {
+	return s == Scheduled || s == InProgress || s == Rescheduled
+}
+
+// Label returns a human-friendly label for display (e.g. badges). It only differs
+// from the raw value for the camelCase compound statuses.
+func (s FixtureStatus) Label() string {
+	switch s {
+	case InProgress:
+		return "In Progress"
+	case AwaitingReschedule:
+		return "Awaiting Reschedule"
+	default:
+		return string(s)
+	}
+}
 
 // RescheduledReason represents the reason for rescheduling a fixture
 type RescheduledReason string

--- a/internal/repository/fixture.go
+++ b/internal/repository/fixture.go
@@ -90,7 +90,7 @@ func NewFixtureRepository(db *database.DB) FixtureRepository {
 // fixtureColumns is the standard set of columns for fixture queries
 const fixtureColumns = `id, home_team_id, away_team_id, division_id, season_id, week_id, scheduled_date,
 	venue_location, status, completed_date, day_captain_id, external_match_card_id, notes,
-	venue_club_id, created_at, updated_at`
+	previous_dates, rescheduled_reason, venue_club_id, created_at, updated_at`
 
 // fixtureColumnsWithPrefix returns fixture columns prefixed with a table alias
 func fixtureColumnsWithPrefix(prefix string) string {
@@ -98,6 +98,7 @@ func fixtureColumnsWithPrefix(prefix string) string {
 		prefix + ".season_id, " + prefix + ".week_id, " + prefix + ".scheduled_date, " +
 		prefix + ".venue_location, " + prefix + ".status, " + prefix + ".completed_date, " + prefix + ".day_captain_id, " +
 		prefix + ".external_match_card_id, " + prefix + ".notes, " +
+		prefix + ".previous_dates, " + prefix + ".rescheduled_reason, " +
 		prefix + ".venue_club_id, " + prefix + ".created_at, " + prefix + ".updated_at"
 }
 
@@ -135,10 +136,10 @@ func (r *fixtureRepository) Create(ctx context.Context, fixture *models.Fixture)
 	result, err := r.db.NamedExecContext(ctx, `
 		INSERT INTO fixtures (home_team_id, away_team_id, division_id, season_id, week_id, scheduled_date,
 		                     venue_location, status, completed_date, day_captain_id, external_match_card_id, notes,
-		                     venue_club_id, created_at, updated_at)
+		                     previous_dates, rescheduled_reason, venue_club_id, created_at, updated_at)
 		VALUES (:home_team_id, :away_team_id, :division_id, :season_id, :week_id, :scheduled_date,
 		        :venue_location, :status, :completed_date, :day_captain_id, :external_match_card_id, :notes,
-		        :venue_club_id, :created_at, :updated_at)
+		        :previous_dates, :rescheduled_reason, :venue_club_id, :created_at, :updated_at)
 	`, fixture)
 
 	if err != nil {
@@ -163,6 +164,7 @@ func (r *fixtureRepository) Update(ctx context.Context, fixture *models.Fixture)
 		    season_id = :season_id, week_id = :week_id, scheduled_date = :scheduled_date, venue_location = :venue_location,
 		    status = :status, completed_date = :completed_date, day_captain_id = :day_captain_id,
 		    external_match_card_id = :external_match_card_id, notes = :notes,
+		    previous_dates = :previous_dates, rescheduled_reason = :rescheduled_reason,
 		    venue_club_id = :venue_club_id, updated_at = :updated_at
 		WHERE id = :id
 	`, fixture)

--- a/internal/repository/fixture.go
+++ b/internal/repository/fixture.go
@@ -282,9 +282,9 @@ func (r *fixtureRepository) FindByClubAndDateRange(ctx context.Context, clubID u
         INNER JOIN teams ta ON ta.id = f.away_team_id
         WHERE (th.club_id = ? OR ta.club_id = ?)
           AND f.scheduled_date >= ? AND f.scheduled_date <= ?
-          AND f.status IN (?, ?)
+          AND f.status IN (?, ?, ?)
         ORDER BY f.scheduled_date ASC
-    `, clubID, clubID, startDate, endDate, string(models.Scheduled), string(models.InProgress))
+    `, clubID, clubID, startDate, endDate, string(models.Scheduled), string(models.InProgress), string(models.Rescheduled))
 	return fixtures, err
 }
 
@@ -371,10 +371,10 @@ func (r *fixtureRepository) FindUpcoming(ctx context.Context, limit int) ([]mode
 	err := r.db.SelectContext(ctx, &fixtures, `
 		SELECT `+fixtureColumns+`
 		FROM fixtures 
-		WHERE scheduled_date >= CURRENT_TIMESTAMP AND status IN (?, ?)
+		WHERE scheduled_date >= CURRENT_TIMESTAMP AND status IN (?, ?, ?)
 		ORDER BY scheduled_date ASC
 		LIMIT ?
-	`, string(models.Scheduled), string(models.InProgress), limit)
+	`, string(models.Scheduled), string(models.InProgress), string(models.Rescheduled), limit)
 	return fixtures, err
 }
 
@@ -422,9 +422,9 @@ func (r *fixtureRepository) FindOverdue(ctx context.Context) ([]models.Fixture, 
 	err := r.db.SelectContext(ctx, &fixtures, `
 		SELECT `+fixtureColumns+`
 		FROM fixtures 
-		WHERE scheduled_date < CURRENT_TIMESTAMP AND status = ?
+		WHERE scheduled_date < CURRENT_TIMESTAMP AND status IN (?, ?)
 		ORDER BY scheduled_date ASC
-	`, string(models.Scheduled))
+	`, string(models.Scheduled), string(models.Rescheduled))
 	return fixtures, err
 }
 
@@ -604,7 +604,7 @@ func (r *fixtureRepository) FindUpcomingFixturesForPlayer(ctx context.Context, p
 		INNER JOIN fixture_players fp ON f.id = fp.fixture_id
 		WHERE fp.player_id = ?
 		  AND date(f.scheduled_date) >= date('now')
-		  AND f.status IN ('Scheduled', 'InProgress')
+		  AND f.status IN ('Scheduled', 'InProgress', 'Rescheduled')
 				ORDER BY f.scheduled_date ASC
 	`, playerID)
 

--- a/internal/services/matchcard_service.go
+++ b/internal/services/matchcard_service.go
@@ -47,6 +47,10 @@ type ImportConfig struct {
 	DryRun                bool          // If true, don't save to database
 	Verbose               bool          // If true, output detailed logs
 	ClearExistingMatchups bool          // If true, clear existing matchups before processing
+	// ClearUnplayedPairings, when true, also clears player selections on fixtures the
+	// post-import sweep flips to AwaitingReschedule (their window passed with no
+	// result). Captains treat a fixture that needs rescheduling as a clean slate.
+	ClearUnplayedPairings bool
 }
 
 // ImportResult holds the results of an import operation
@@ -56,8 +60,12 @@ type ImportResult struct {
 	CreatedMatchups  int
 	UpdatedMatchups  int
 	MatchedPlayers   int
-	UnmatchedPlayers []string
-	Errors           []string
+	// AwaitingRescheduleFixtures counts home-club fixtures the post-import sweep
+	// flipped to AwaitingReschedule (window passed, no result imported). On a dry
+	// run this reports how many WOULD be flipped without persisting.
+	AwaitingRescheduleFixtures int
+	UnmatchedPlayers           []string
+	Errors                     []string
 }
 
 // NewMatchCardService creates a new match card service
@@ -167,12 +175,131 @@ func (s *MatchCardService) ImportWeekMatchCards(ctx context.Context, config Impo
 		totalResult.Errors = append(totalResult.Errors, result.Errors...)
 	}
 
+	// After processing all cards, sweep any home-club fixtures for this week whose
+	// play window has passed with no result imported: flip them to AwaitingReschedule
+	// so captains know a new date is needed. Fixtures that got a card above are now
+	// Completed and are excluded from the sweep.
+	swept, err := s.sweepUnplayedFixtures(ctx, config, week)
+	if err != nil {
+		// Non-fatal: the import itself succeeded. Surface as a warning.
+		totalResult.Errors = append(totalResult.Errors,
+			fmt.Sprintf("Failed to sweep unplayed fixtures for week %d: %v", week, err))
+	} else {
+		totalResult.AwaitingRescheduleFixtures += swept
+	}
+
 	// Rate limiting
 	if config.RateLimit > 0 {
 		time.Sleep(config.RateLimit)
 	}
 
 	return totalResult, nil
+}
+
+// sweepUnplayedFixtures marks home-club fixtures for the given league week as
+// AwaitingReschedule when their start time has passed and no match card imported a
+// result. Importing implies the cards are ready, so a started home-club fixture with
+// no result genuinely needs rescheduling. It returns the number of fixtures affected
+// (or, on a dry run, the number that would be affected). When
+// config.ClearUnplayedPairings is set, it also clears player selections on the swept
+// fixtures.
+func (s *MatchCardService) sweepUnplayedFixtures(ctx context.Context, config ImportConfig, week int) (int, error) {
+	// Resolve the season(s) for the import year. Normally one per year for a league.
+	seasons, err := s.seasonRepo.FindByYear(ctx, config.Year)
+	if err != nil {
+		return 0, fmt.Errorf("failed to look up seasons for year %d: %w", config.Year, err)
+	}
+	if len(seasons) == 0 {
+		return 0, nil // Nothing to sweep — no season for this year
+	}
+
+	now := time.Now()
+	swept := 0
+
+	for _, season := range seasons {
+		fixtures, err := s.fixtureRepo.FindByWeekNumber(ctx, season.ID, week)
+		if err != nil {
+			return swept, fmt.Errorf("failed to load fixtures for season %d week %d: %w", season.ID, week, err)
+		}
+
+		for i := range fixtures {
+			fixture := fixtures[i]
+
+			// Only sweep fixtures still awaiting play (Scheduled/InProgress/Rescheduled).
+			// Completed/Cancelled/Postponed and already-AwaitingReschedule are skipped.
+			if !fixture.Status.IsPending() {
+				continue
+			}
+
+			// Only sweep once the fixture's start time has passed. If we're importing,
+			// the match cards are ready, so a started fixture with no imported result
+			// genuinely has no result — it needs rescheduling.
+			if !now.After(fixture.ScheduledDate) {
+				continue
+			}
+
+			// Only sweep fixtures the home club is involved in — those are the ones
+			// this app manages selections for.
+			involvesHomeClub, err := s.fixtureInvolvesHomeClub(ctx, &fixture)
+			if err != nil {
+				return swept, err
+			}
+			if !involvesHomeClub {
+				continue
+			}
+
+			swept++
+
+			if config.Verbose {
+				fmt.Printf("Sweep: fixture %d (%s) window passed with no result — marking AwaitingReschedule\n",
+					fixture.ID, fixture.ScheduledDate.Format("2006-01-02 15:04"))
+			}
+
+			if config.DryRun {
+				continue
+			}
+
+			if err := s.fixtureRepo.UpdateStatus(ctx, fixture.ID, models.AwaitingReschedule); err != nil {
+				return swept, fmt.Errorf("failed to mark fixture %d AwaitingReschedule: %w", fixture.ID, err)
+			}
+
+			if config.ClearUnplayedPairings {
+				if err := s.fixtureRepo.ClearSelectedPlayers(ctx, fixture.ID); err != nil {
+					return swept, fmt.Errorf("failed to clear selections on fixture %d: %w", fixture.ID, err)
+				}
+				// Also remove the matchups (the doubles pairings). Clearing the squad
+				// selection alone leaves stale pairings on a fixture that needs
+				// rescheduling — the captain expects a clean slate.
+				if err := s.clearExistingMatchups(ctx, config, fixture.ID, false, 0, 0); err != nil {
+					return swept, fmt.Errorf("failed to clear matchups on fixture %d: %w", fixture.ID, err)
+				}
+			}
+		}
+	}
+
+	return swept, nil
+}
+
+// fixtureInvolvesHomeClub reports whether either team in the fixture belongs to the
+// home club.
+func (s *MatchCardService) fixtureInvolvesHomeClub(ctx context.Context, fixture *models.Fixture) (bool, error) {
+	homeTeam, err := s.teamRepo.FindByID(ctx, fixture.HomeTeamID)
+	if err != nil {
+		return false, fmt.Errorf("failed to load home team %d: %w", fixture.HomeTeamID, err)
+	}
+	if homeTeam != nil && homeTeam.ClubID == s.homeClubID {
+		return true, nil
+	}
+
+	awayTeam, err := s.teamRepo.FindByID(ctx, fixture.AwayTeamID)
+	if err != nil {
+		return false, fmt.Errorf("failed to load away team %d: %w", fixture.AwayTeamID, err)
+	}
+	if awayTeam != nil && awayTeam.ClubID == s.homeClubID {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // fetchMatchCards fetches match card data from BHPLTA API

--- a/migrations/029_add_reschedule_statuses.down.sql
+++ b/migrations/029_add_reschedule_statuses.down.sql
@@ -1,0 +1,16 @@
+-- Revert to the original insert-only guard with the pre-029 status set.
+-- Any fixtures left in 'Rescheduled' or 'AwaitingReschedule' are folded back to
+-- 'Scheduled' first so the restored trigger does not reject later updates to them.
+
+UPDATE fixtures SET status = 'Scheduled' WHERE status IN ('Rescheduled', 'AwaitingReschedule');
+
+DROP TRIGGER IF EXISTS chk_valid_fixture_status_update;
+DROP TRIGGER IF EXISTS chk_valid_fixture_status;
+
+CREATE TRIGGER IF NOT EXISTS chk_valid_fixture_status
+BEFORE INSERT ON fixtures
+FOR EACH ROW
+WHEN NEW.status NOT IN ('Scheduled', 'InProgress', 'Completed', 'Cancelled', 'Postponed')
+BEGIN
+    SELECT RAISE(FAIL, 'Invalid fixture status');
+END;

--- a/migrations/029_add_reschedule_statuses.up.sql
+++ b/migrations/029_add_reschedule_statuses.up.sql
@@ -1,0 +1,40 @@
+-- Add two fixture statuses that surface the reschedule lifecycle:
+--   'Rescheduled'        - a still-to-be-played fixture that a captain moved to a
+--                          new future date. Behaves like 'Scheduled' for selection
+--                          and availability, but is distinguishable for display and
+--                          for the played-down rule.
+--   'AwaitingReschedule' - a fixture whose play window has passed with no match card
+--                          imported. The post-import sweep flips leftover fixtures
+--                          into this status so captains know they need a new date.
+--
+-- The original chk_valid_fixture_status trigger (migration 001) only guarded
+-- INSERTs. Reschedule and the import sweep both UPDATE the status, so recreate the
+-- guard for both INSERT and UPDATE with the expanded valid set.
+
+DROP TRIGGER IF EXISTS chk_valid_fixture_status;
+
+CREATE TRIGGER IF NOT EXISTS chk_valid_fixture_status
+BEFORE INSERT ON fixtures
+FOR EACH ROW
+WHEN NEW.status NOT IN ('Scheduled', 'InProgress', 'Completed', 'Cancelled', 'Postponed', 'Rescheduled', 'AwaitingReschedule')
+BEGIN
+    SELECT RAISE(FAIL, 'Invalid fixture status');
+END;
+
+CREATE TRIGGER IF NOT EXISTS chk_valid_fixture_status_update
+BEFORE UPDATE ON fixtures
+FOR EACH ROW
+WHEN NEW.status NOT IN ('Scheduled', 'InProgress', 'Completed', 'Cancelled', 'Postponed', 'Rescheduled', 'AwaitingReschedule')
+BEGIN
+    SELECT RAISE(FAIL, 'Invalid fixture status');
+END;
+
+-- Backfill fixtures that were already rescheduled through the app before this
+-- migration. The old reschedule flow never set a status, so they are still
+-- 'Scheduled' with a rescheduled_reason recorded. Reclassify the still-pending
+-- ones as 'Rescheduled' so they display correctly. Completed/Cancelled/Postponed
+-- fixtures are untouched; any whose (new) date has already passed without a result
+-- will be picked up by the next import sweep and moved to 'AwaitingReschedule'.
+UPDATE fixtures
+SET status = 'Rescheduled'
+WHERE status = 'Scheduled' AND rescheduled_reason IS NOT NULL;

--- a/static/css/fixture-detail.css
+++ b/static/css/fixture-detail.css
@@ -142,6 +142,16 @@
     color: white;
 }
 
+.status-badge.Rescheduled {
+    background-color: #6610f2;
+    color: white;
+}
+
+.status-badge.AwaitingReschedule {
+    background-color: #fd7e14;
+    color: white;
+}
+
 .detail-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));

--- a/templates/admin/fixture_detail.html
+++ b/templates/admin/fixture_detail.html
@@ -59,7 +59,7 @@
                         <span class="vs-text">vs</span>
                         <span class="team-name">{{if .FixtureDetail.AwayTeam}}{{.FixtureDetail.AwayTeam.Name}}{{else}}TBD{{end}}</span>
                     </p>
-                    <span class="status-badge {{.FixtureDetail.Status}}">{{.FixtureDetail.Status}}</span>
+                    <span class="status-badge {{.FixtureDetail.Status}}">{{.FixtureDetail.Status.Label}}</span>
                 </div>
 
             {{template "admin/partials/derby_management.html" .}}

--- a/templates/admin/fixture_edit.html
+++ b/templates/admin/fixture_edit.html
@@ -70,12 +70,13 @@
                         <form method="POST" action="/admin/league/fixtures/{{.FixtureDetail.ID}}/edit" class="fixture-edit-form">
                             <div class="form-group">
                                 <label for="scheduled_date">New Scheduled Date:</label>
-                                <input type="datetime-local" 
-                                       id="scheduled_date" 
-                                       name="scheduled_date" 
+                                <input type="datetime-local"
+                                       id="scheduled_date"
+                                       name="scheduled_date"
                                        value="{{.FixtureDetail.ScheduledDate.Format "2006-01-02T15:04"}}"
+                                       {{if .FixtureDetail.Season}}min="{{.FixtureDetail.Season.StartDate.Format "2006-01-02T15:04"}}" max="{{.FixtureDetail.Season.EndDate.Format "2006-01-02T15:04"}}"{{end}}
                                        required>
-                                <small class="form-help">Current time: {{.FixtureDetail.ScheduledDate.Format "Monday, 2 January 2006 at 15:04"}}</small>
+                                <small class="form-help">Current time: {{.FixtureDetail.ScheduledDate.Format "Monday, 2 January 2006 at 15:04"}}{{if .FixtureDetail.Season}} · must be within the {{.FixtureDetail.Season.Year}} season{{end}}</small>
                             </div>
 
                             <div class="form-group">

--- a/templates/admin/fixture_edit.html
+++ b/templates/admin/fixture_edit.html
@@ -46,7 +46,7 @@
                         <span class="vs-text">vs</span>
                         <span class="team-name">{{if .FixtureDetail.AwayTeam}}{{.FixtureDetail.AwayTeam.Name}}{{else}}TBD{{end}}</span>
                     </p>
-                    <span class="status-badge {{.FixtureDetail.Status}}">{{.FixtureDetail.Status}}</span>
+                    <span class="status-badge {{.FixtureDetail.Status}}">{{.FixtureDetail.Status.Label}}</span>
                 </div>
 
                 {{if .Error}}

--- a/templates/admin/fixture_team_selection.html
+++ b/templates/admin/fixture_team_selection.html
@@ -1011,19 +1011,19 @@
                         <h5>⚖️ Eligibility Status:</h5>
                         <div class="legend-item">
                             <span>✅</span>
-                            Free to play - Can play in lower divisions (remaining count shown)
+                            Eligible to play here. The number counts games left before they'd be locked to this team (then can't drop to a lower team)
                         </div>
                         <div class="legend-item">
                             <span>🔒</span>
-                            Locked - 4+ matches played (locked to this team or higher)
+                            Eligible here, but locked to this team — can't drop to a lower team (played 5+ at this level)
                         </div>
                         <div class="legend-item">
                             <span>⚠️</span>
-                            Warning - Already played this week (rule suggestion, can still select)
+                            Already played this week (rule suggestion, can still select)
                         </div>
                         <div class="legend-item">
                             <span>🚫</span>
-                            Blocked - Locked to higher division team
+                            Not eligible — locked to a higher team (played 5+ for them)
                         </div>
                     </div>
                     
@@ -1061,13 +1061,15 @@
                                     {{if .Eligibility.PlayedThisWeek}}
                                       {{$title = printf "%s | ⚠️ Already played this week for %s (rule suggestion)" $title .Eligibility.PlayedThisWeekTeam}}
                                     {{else if .Eligibility.IsLockedToHigherTeam}}
-                                      {{$title = printf "%s | 🚫 Locked to %s" $title .Eligibility.LockedToTeamName}}
+                                      {{$title = printf "%s | 🚫 Locked to %s — not eligible here (played 5+ for them)" $title .Eligibility.LockedToTeamName}}
                                     {{end}}
                                   {{else if .Eligibility.IsLocked}}
-                                    {{$title = printf "%s | 🔒 Locked to this team or higher" $title}}
+                                    {{$title = printf "%s | 🔒 Eligible here, but locked to this team (can't drop to a lower team)" $title}}
                                   {{else if .Eligibility.CanPlayLower}}
-                                    {{if ge .Eligibility.RemainingHigherTeamPlays 0}}
-                                      {{$title = printf "%s | ✅ %d plays left" $title .Eligibility.RemainingHigherTeamPlays}}
+                                    {{if gt .Eligibility.RemainingHigherTeamPlays 0}}
+                                      {{$title = printf "%s | ✅ Eligible — %d game(s) before locked to this team (then can't drop lower)" $title .Eligibility.RemainingHigherTeamPlays}}
+                                    {{else if eq .Eligibility.RemainingHigherTeamPlays 0}}
+                                      {{$title = printf "%s | ✅ Eligible — can play here; after this they're locked to this team (can't drop lower)" $title}}
                                     {{else}}
                                       {{$title = printf "%s | ✅ Can play lower teams" $title}}
                                     {{end}}
@@ -1091,7 +1093,11 @@
                                 {{$remainingText := ""}}
                                 {{if .Eligibility}}
                                   {{if and .Eligibility.CanPlayLower (ge .Eligibility.RemainingHigherTeamPlays 0)}}
-                                    {{$remainingText = printf " (%d left)" .Eligibility.RemainingHigherTeamPlays}}
+                                    {{if eq .Eligibility.RemainingHigherTeamPlays 0}}
+                                      {{$remainingText = " · locked after this"}}
+                                    {{else}}
+                                      {{$remainingText = printf " · %d before locked" .Eligibility.RemainingHigherTeamPlays}}
+                                    {{end}}
                                   {{end}}
                                 {{end}}
                                 
@@ -1146,13 +1152,15 @@
                                     {{if .Eligibility.PlayedThisWeek}}
                                       {{$title = printf "%s | ⚠️ Already played this week for %s (rule suggestion)" $title .Eligibility.PlayedThisWeekTeam}}
                                     {{else if .Eligibility.IsLockedToHigherTeam}}
-                                      {{$title = printf "%s | 🚫 Locked to %s" $title .Eligibility.LockedToTeamName}}
+                                      {{$title = printf "%s | 🚫 Locked to %s — not eligible here (played 5+ for them)" $title .Eligibility.LockedToTeamName}}
                                     {{end}}
                                   {{else if .Eligibility.IsLocked}}
-                                    {{$title = printf "%s | 🔒 Locked to this team or higher" $title}}
+                                    {{$title = printf "%s | 🔒 Eligible here, but locked to this team (can't drop to a lower team)" $title}}
                                   {{else if .Eligibility.CanPlayLower}}
-                                    {{if ge .Eligibility.RemainingHigherTeamPlays -1}}
-                                      {{$title = printf "%s | ✅ %d plays left" $title .Eligibility.RemainingHigherTeamPlays}}
+                                    {{if gt .Eligibility.RemainingHigherTeamPlays 0}}
+                                      {{$title = printf "%s | ✅ Eligible — %d game(s) before locked to this team (then can't drop lower)" $title .Eligibility.RemainingHigherTeamPlays}}
+                                    {{else if eq .Eligibility.RemainingHigherTeamPlays 0}}
+                                      {{$title = printf "%s | ✅ Eligible — can play here; after this they're locked to this team (can't drop lower)" $title}}
                                     {{else}}
                                       {{$title = printf "%s | ✅ Can play lower teams" $title}}
                                     {{end}}
@@ -1175,8 +1183,12 @@
                                 
                                 {{$remainingText := ""}}
                                 {{if .Eligibility}}
-                                  {{if and .Eligibility.CanPlayLower (ge .Eligibility.RemainingHigherTeamPlays -1)}}
-                                    {{$remainingText = printf " (%d left)" .Eligibility.RemainingHigherTeamPlays}}
+                                  {{if and .Eligibility.CanPlayLower (ge .Eligibility.RemainingHigherTeamPlays 0)}}
+                                    {{if eq .Eligibility.RemainingHigherTeamPlays 0}}
+                                      {{$remainingText = " · locked after this"}}
+                                    {{else}}
+                                      {{$remainingText = printf " · %d before locked" .Eligibility.RemainingHigherTeamPlays}}
+                                    {{end}}
                                   {{end}}
                                 {{end}}
                                 

--- a/templates/admin/fixture_team_selection_container.html
+++ b/templates/admin/fixture_team_selection_container.html
@@ -412,19 +412,19 @@
             <h5>⚖️ Eligibility Status:</h5>
             <div class="legend-item">
                 <span>✅</span>
-                Free to play - Can play in lower divisions (remaining count shown)
+                Eligible to play here. The number counts games left before they'd be locked to this team (then can't drop to a lower team)
             </div>
             <div class="legend-item">
                 <span>🔒</span>
-                Locked - 4+ matches played (locked to this team or higher)
+                Eligible here, but locked to this team — can't drop to a lower team (played 5+ at this level)
             </div>
             <div class="legend-item">
                 <span>⚠️</span>
-                Warning - Already played this week (rule suggestion, can still select)
+                Already played this week (rule suggestion, can still select)
             </div>
             <div class="legend-item">
                 <span>🚫</span>
-                Blocked - Locked to higher division team
+                Not eligible — locked to a higher team (played 5+ for them)
             </div>
         </div>
         
@@ -461,13 +461,15 @@
                         {{if .Eligibility.PlayedThisWeek}}
                           {{$title = printf "%s | ⚠️ Already played this week for %s (rule suggestion)" $title .Eligibility.PlayedThisWeekTeam}}
                         {{else if .Eligibility.IsLockedToHigherTeam}}
-                          {{$title = printf "%s | 🚫 Locked to %s" $title .Eligibility.LockedToTeamName}}
+                          {{$title = printf "%s | 🚫 Locked to %s — not eligible here (played 5+ for them)" $title .Eligibility.LockedToTeamName}}
                         {{end}}
                       {{else if .Eligibility.IsLocked}}
-                        {{$title = printf "%s | 🔒 Locked to this team or higher" $title}}
+                        {{$title = printf "%s | 🔒 Eligible here, but locked to this team (can't drop to a lower team)" $title}}
                       {{else if .Eligibility.CanPlayLower}}
-                        {{if ge .Eligibility.RemainingHigherTeamPlays 0}}
-                          {{$title = printf "%s | ✅ %d plays left" $title .Eligibility.RemainingHigherTeamPlays}}
+                        {{if gt .Eligibility.RemainingHigherTeamPlays 0}}
+                          {{$title = printf "%s | ✅ Eligible — %d game(s) before locked to this team (then can't drop lower)" $title .Eligibility.RemainingHigherTeamPlays}}
+                        {{else if eq .Eligibility.RemainingHigherTeamPlays 0}}
+                          {{$title = printf "%s | ✅ Eligible — can play here; after this they're locked to this team (can't drop lower)" $title}}
                         {{else}}
                           {{$title = printf "%s | ✅ Can play lower teams" $title}}
                         {{end}}
@@ -491,7 +493,11 @@
                     {{$remainingText := ""}}
                     {{if .Eligibility}}
                       {{if and .Eligibility.CanPlayLower (ge .Eligibility.RemainingHigherTeamPlays 0)}}
-                        {{$remainingText = printf " (%d left)" .Eligibility.RemainingHigherTeamPlays}}
+                        {{if eq .Eligibility.RemainingHigherTeamPlays 0}}
+                          {{$remainingText = " · locked after this"}}
+                        {{else}}
+                          {{$remainingText = printf " · %d before locked" .Eligibility.RemainingHigherTeamPlays}}
+                        {{end}}
                       {{end}}
                     {{end}}
                     
@@ -545,13 +551,15 @@
                         {{if .Eligibility.PlayedThisWeek}}
                           {{$title = printf "%s | ⚠️ Already played this week for %s (rule suggestion)" $title .Eligibility.PlayedThisWeekTeam}}
                         {{else if .Eligibility.IsLockedToHigherTeam}}
-                          {{$title = printf "%s | 🚫 Locked to %s" $title .Eligibility.LockedToTeamName}}
+                          {{$title = printf "%s | 🚫 Locked to %s — not eligible here (played 5+ for them)" $title .Eligibility.LockedToTeamName}}
                         {{end}}
                       {{else if .Eligibility.IsLocked}}
-                        {{$title = printf "%s | 🔒 Locked to this team or higher" $title}}
+                        {{$title = printf "%s | 🔒 Eligible here, but locked to this team (can't drop to a lower team)" $title}}
                       {{else if .Eligibility.CanPlayLower}}
-                        {{if ge .Eligibility.RemainingHigherTeamPlays 0}}
-                          {{$title = printf "%s | ✅ %d plays left" $title .Eligibility.RemainingHigherTeamPlays}}
+                        {{if gt .Eligibility.RemainingHigherTeamPlays 0}}
+                          {{$title = printf "%s | ✅ Eligible — %d game(s) before locked to this team (then can't drop lower)" $title .Eligibility.RemainingHigherTeamPlays}}
+                        {{else if eq .Eligibility.RemainingHigherTeamPlays 0}}
+                          {{$title = printf "%s | ✅ Eligible — can play here; after this they're locked to this team (can't drop lower)" $title}}
                         {{else}}
                           {{$title = printf "%s | ✅ Can play lower teams" $title}}
                         {{end}}
@@ -575,7 +583,11 @@
                     {{$remainingText := ""}}
                     {{if .Eligibility}}
                       {{if and .Eligibility.CanPlayLower (ge .Eligibility.RemainingHigherTeamPlays 0)}}
-                        {{$remainingText = printf " (%d left)" .Eligibility.RemainingHigherTeamPlays}}
+                        {{if eq .Eligibility.RemainingHigherTeamPlays 0}}
+                          {{$remainingText = " · locked after this"}}
+                        {{else}}
+                          {{$remainingText = printf " · %d before locked" .Eligibility.RemainingHigherTeamPlays}}
+                        {{end}}
                       {{end}}
                     {{end}}
                     

--- a/templates/admin/fixtures.html
+++ b/templates/admin/fixtures.html
@@ -213,6 +213,16 @@
             /* Light gray */
         }
 
+        .status-Rescheduled {
+            background-color: rgba(102, 16, 242, 0.1);
+            /* Light purple */
+        }
+
+        .status-AwaitingReschedule {
+            background-color: rgba(253, 126, 20, 0.12);
+            /* Light orange */
+        }
+
         /* Status badge */
         .status-badge {
             padding: 0.25rem 0.5rem;
@@ -245,6 +255,56 @@
         .status-badge.Postponed {
             background-color: #6c757d;
             color: white;
+        }
+
+        .status-badge.Rescheduled {
+            background-color: #6610f2;
+            color: white;
+        }
+
+        .status-badge.AwaitingReschedule {
+            background-color: #fd7e14;
+            color: white;
+        }
+
+        /* Awaiting Reschedule prominent section */
+        .awaiting-reschedule-section {
+            border: 2px solid #fd7e14;
+            border-radius: 8px;
+            background-color: rgba(253, 126, 20, 0.06);
+            padding: 1rem 1.25rem 1.25rem;
+            margin-bottom: 1.5rem;
+        }
+
+        .awaiting-reschedule-section .section-header h2 {
+            color: #c25e00;
+        }
+
+        .awaiting-reschedule-section .awaiting-note {
+            margin: 0.25rem 0 1rem;
+            color: #7a5230;
+            font-size: 0.9rem;
+        }
+
+        .section-count.awaiting-count {
+            background-color: #fd7e14;
+            color: white;
+        }
+
+        .btn-reschedule {
+            display: inline-block;
+            background-color: #fd7e14;
+            color: white;
+            padding: 0.4rem 0.75rem;
+            border-radius: 4px;
+            text-decoration: none;
+            font-size: 0.85rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .btn-reschedule:hover {
+            background-color: #e26f0c;
         }
 
         /* Responsive columns */
@@ -460,7 +520,9 @@
                         🔔 Remind All
                     </button>
                     <span id="remind-all-result" style="font-size: 0.875rem;"></span>
+                    {{if and .ActiveSeason (not .ActiveSeason.HasStarted)}}
                     <button onclick="showCreateFixtureModal()" class="btn-add" style="background: var(--primary-color); color: white; padding: 0.5rem 1rem; border: none; border-radius: 4px; cursor: pointer;">➕ Create Fixture</button>
+                    {{end}}
                     <a href="/admin/league/fixtures/week-overview" class="btn-add" style="background: var(--success-color); color: white; padding: 0.5rem 1rem; text-decoration: none; border-radius: 4px;">📱 Week Overview</a>
                 </div>
             </div>
@@ -472,6 +534,60 @@
                 {{if .Club.Website}}<p><strong>Website:</strong> <a href="{{.Club.Website}}"
                         target="_blank">{{.Club.Website}}</a></p>{{end}}
                 {{if .Club.PhoneNumber}}<p><strong>Phone:</strong> {{.Club.PhoneNumber}}</p>{{end}}
+            </div>
+            {{end}}
+
+            <!-- Awaiting Reschedule Section: fixtures whose window passed with no
+                 result. Prominently surfaced to nudge captains to set a new date. -->
+            {{if .AwaitingReschedule}}
+            <div class="awaiting-reschedule-section">
+                <div class="section-header">
+                    <h2>⏳ Awaiting Reschedule</h2>
+                    <span class="section-count awaiting-count">{{len .AwaitingReschedule}}</span>
+                </div>
+                <p class="awaiting-note">These fixtures passed their date without a result. Please set a new date so players show as available again.</p>
+                <div class="table-container">
+                    <table class="fixtures-table">
+                        <thead>
+                            <tr>
+                                <th class="col-date">Was Due</th>
+                                <th class="col-teams">Teams</th>
+                                <th>Week</th>
+                                <th>Division</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {{range .AwaitingReschedule}}
+                            <tr class="status-AwaitingReschedule fixture-row"
+                                onclick="window.location.href='{{if .IsDerby}}/admin/league/fixtures/{{.ID}}?managingTeam={{.DefaultTeamContext.ID}}&teamName={{.DefaultTeamContext.Name}}{{else}}/admin/league/fixtures/{{.ID}}{{end}}'" style="cursor: pointer;">
+                                <td class="col-date">
+                                    <div class="date-time">
+                                        {{.ScheduledDate.Format "Mon, Jan 2"}}
+                                    </div>
+                                </td>
+                                <td class="col-teams">
+                                    {{if .IsDerby}}
+                                    <span class="derby-indicator">⚽ DERBY:</span>
+                                    <span class="team-name derby-home-team">{{if .HomeTeam}}{{.HomeTeam.Name}}{{else}}TBD{{end}}</span>
+                                    <span class="vs-text">vs</span>
+                                    <span class="team-name derby-away-team">{{if .AwayTeam}}{{.AwayTeam.Name}}{{else}}TBD{{end}}</span>
+                                    {{else}}
+                                    <span class="team-name">{{if .HomeTeam}}{{.HomeTeam.Name}}{{else}}TBD{{end}}</span>
+                                    <span class="vs-text">vs</span>
+                                    <span class="team-name">{{if .AwayTeam}}{{.AwayTeam.Name}}{{else}}TBD{{end}}</span>
+                                    {{end}}
+                                </td>
+                                <td>{{if .Week}}Week {{.Week.WeekNumber}}{{else}}TBD{{end}}</td>
+                                <td>{{if .Division}}{{.Division.Name}}{{else}}TBD{{end}}</td>
+                                <td>
+                                    <a href="/admin/league/fixtures/{{.ID}}/edit" class="btn-reschedule" onclick="event.stopPropagation()">📅 Reschedule</a>
+                                </td>
+                            </tr>
+                            {{end}}
+                        </tbody>
+                    </table>
+                </div>
             </div>
             {{end}}
 
@@ -682,7 +798,7 @@
                                         {{if .Division}}{{.Division.Name}}{{else}}TBD{{end}}
                                     </td>
                                     <td class="col-status">
-                                        <span class="status-badge {{.Status}}">{{.Status}}</span>
+                                        <span class="status-badge {{.Status}}">{{.Status.Label}}</span>
                                     </td>
                                 </tr>
                                 {{end}}

--- a/templates/admin/match_card_importation.html
+++ b/templates/admin/match_card_importation.html
@@ -359,6 +359,18 @@
 
                                     <div class="form-group">
                                         <div class="form-check">
+                                            <input class="form-check-input" type="checkbox" id="clear_unplayed_pairings" name="clear_unplayed_pairings" checked>
+                                            <label class="form-check-label" for="clear_unplayed_pairings">
+                                                Clear Pairings on Unplayed Fixtures
+                                            </label>
+                                            <small class="form-text text-muted">
+                                                🧹 Fixtures whose window passed with no result are marked <strong>Awaiting Reschedule</strong>. When ticked, their player selections are cleared so the fixture starts fresh when rescheduled.
+                                            </small>
+                                        </div>
+                                    </div>
+
+                                    <div class="form-group">
+                                        <div class="form-check">
                                             <input class="form-check-input" type="checkbox" id="dry_run" name="dry_run">
                                             <label class="form-check-label" for="dry_run">
                                                 Dry Run Mode

--- a/templates/admin_standalone.html
+++ b/templates/admin_standalone.html
@@ -29,6 +29,69 @@
             text-align: center;
         }
 
+        /* Awaiting Reschedule dashboard banner */
+        .awaiting-reschedule-banner {
+            border: 2px solid #fd7e14;
+            border-left-width: 6px;
+            border-radius: 8px;
+            background-color: rgba(253, 126, 20, 0.07);
+            padding: 1rem 1.25rem;
+            margin-bottom: 1.5rem;
+        }
+
+        .awaiting-banner-head {
+            font-size: 1.15rem;
+            color: #c25e00;
+        }
+
+        .awaiting-banner-icon {
+            margin-right: 0.35rem;
+        }
+
+        .awaiting-banner-note {
+            margin: 0.35rem 0 0.75rem;
+            color: #7a5230;
+            font-size: 0.9rem;
+        }
+
+        .awaiting-banner-list {
+            list-style: none;
+            margin: 0 0 0.75rem;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+        }
+
+        .awaiting-banner-list a {
+            display: inline-flex;
+            gap: 0.6rem;
+            align-items: baseline;
+            text-decoration: none;
+            color: #333;
+        }
+
+        .awaiting-banner-list a:hover .awaiting-banner-teams {
+            text-decoration: underline;
+        }
+
+        .awaiting-banner-date {
+            color: #c25e00;
+            font-weight: 600;
+            font-size: 0.85rem;
+            min-width: 6.5rem;
+        }
+
+        .awaiting-banner-cta {
+            font-weight: 600;
+            color: #c25e00;
+            text-decoration: none;
+        }
+
+        .awaiting-banner-cta:hover {
+            text-decoration: underline;
+        }
+
         .stat-card-link {
             text-decoration: none;
             color: inherit;
@@ -269,6 +332,27 @@
         <div class="container">
             <div class="admin-container">
                 <h1 data-testid="dashboard-title">Admin Dashboard</h1>
+
+                {{if .AwaitingReschedule}}
+                <div class="awaiting-reschedule-banner">
+                    <div class="awaiting-banner-head">
+                        <span class="awaiting-banner-icon">⏳</span>
+                        <strong>{{len .AwaitingReschedule}}</strong>&nbsp;fixture{{if ne (len .AwaitingReschedule) 1}}s{{end}} awaiting reschedule
+                    </div>
+                    <p class="awaiting-banner-note">These passed their date with no result. Set a new date so players show as available again.</p>
+                    <ul class="awaiting-banner-list">
+                        {{range .AwaitingReschedule}}
+                        <li>
+                            <a href="/admin/league/fixtures/{{.ID}}/edit">
+                                <span class="awaiting-banner-date">{{.ScheduledDate.Format "Mon, Jan 2"}}</span>
+                                <span class="awaiting-banner-teams">{{if .HomeTeam}}{{.HomeTeam.Name}}{{else}}TBD{{end}} vs {{if .AwayTeam}}{{.AwayTeam.Name}}{{else}}TBD{{end}}</span>
+                            </a>
+                        </li>
+                        {{end}}
+                    </ul>
+                    <a href="/admin/league/fixtures" class="awaiting-banner-cta">Go to fixtures →</a>
+                </div>
+                {{end}}
 
                 <div class="admin-stats">
                     <a href="/admin/league/players" class="stat-card-link">


### PR DESCRIPTION
## Summary
Adds a proper reschedule lifecycle for fixtures, fixes the played-down (Rule 16) eligibility bug, surfaces fixtures that need rescheduling, and blocks accidental mid-season fixture creation. All changes are deployed to production and verified.

## Changes
- **New statuses** (migration 029): `Rescheduled` (behaves like Scheduled for selection/availability, tracked distinctly) and `AwaitingReschedule` (window passed with no imported result). Adds `FixtureStatus.IsPending()`/`Label()` helpers.
- **Import sweep**: after importing a week, home-club fixtures past their start time with no result are flipped to `AwaitingReschedule`. New "Clear Pairings on Unplayed Fixtures" checkbox clears their selections **and** matchups. Manual reschedule now sets `Rescheduled` and always clears selections + matchups.
- **Surfacing**: prominent "Awaiting Reschedule" section on the fixtures page (clickable rows, mobile-friendly) and a dashboard banner, to nudge captains to set new dates.
- **Rule 16 fix**: played-down eligibility now counts only `Completed` matches. Previously Scheduled/InProgress fixtures counted, wrongly locking players out of lower teams when a higher-team fixture was never played. Rule 1 (one team per week) still includes `Rescheduled`. Regression test added.
- **Create guard**: block fixture creation once the active season has started (`Season.HasStarted()`); the "Create Fixture" button is hidden in that case. Mid-season date changes are made by rescheduling.
- **Backfill** (migration 029): reclassifies pre-existing app-rescheduled fixtures (`Scheduled` + `rescheduled_reason` set) to `Rescheduled`.

## Testing
- Full `make test` suite passes, incl. the new `TestPlayDownIgnoresUnplayedHigherTeamFixtures` regression test and repository migration tests.
- Full status-usage sweep across Go/SQL/templates/JS confirmed no regressions.
- Deployed to production; migration applied cleanly; behaviour verified against prod data.

https://claude.ai/code/session_01BuyiByYmngvuMusv91fRkX